### PR TITLE
Retain explicit typecasts to user-defined datatypes

### DIFF
--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -43,6 +43,7 @@
 #include "nodes/nodeFuncs.h"
 #include "nodes/subscripting.h"
 #include "optimizer/optimizer.h"
+#include "parser/parse_cypher_expr.h"
 #include "pgstat.h"
 #include "utils/acl.h"
 #include "utils/array.h"
@@ -4311,6 +4312,11 @@ ExecInitCypherMap(ExprEvalStep *scratch, CypherMapExpr *mapexpr,
 		 */
 		Assert(key->consttype == TEXTOID && !key->constisnull);
 		key_cstrings[i] = TextDatumGetCString(key->constvalue);
+
+		if (exprType((Node *) val) != JSONBOID)
+			val = (Expr *) coerce_expr(NULL, (Node *) val, exprType((Node *) val),
+									   JSONBOID, -1 , COERCION_EXPLICIT,
+									   COERCE_EXPLICIT_CAST, -1);
 
 		Assert(exprType((Node *) val) == JSONBOID);
 		ExecInitExprRec(val, state, &val_values[i], &val_nulls[i]);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -18979,6 +18979,15 @@ cypher_expr:
 					n->location = @3;
 					$$ = makeTypeCast($1, n, @2);
 				}
+			| cypher_expr TYPECAST type_function_name '(' cypher_expr_comma_list ')'
+				{
+					TypeName   *n;
+
+					n = (TypeName *) makeTypeName($3);
+					n->typmods = $5;
+					n->location = @3;
+					$$ = makeTypeCast($1, n, @2);
+				}
 			| cypher_expr '.' cypher_expr_escaped_name
 				{
 					A_Indirection *n;

--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -631,8 +631,17 @@ transformTypeCast(ParseState *pstate, TypeCast *tc)
 	if (loc < 0)
 		loc = tc->typeName->location;
 
-	node = coerce_expr(pstate, expr, ityp, otyp, otypmod,
-					   COERCION_EXPLICIT, COERCE_EXPLICIT_CAST, loc);
+	if (otyp != JSONBOID &&
+		TypeCategory(getBaseType(otyp)) == TYPCATEGORY_USER &&
+		can_coerce_type(1, &ityp, &otyp, COERCION_EXPLICIT))
+	{
+		node = coerce_to_target_type(pstate, expr, ityp, otyp, otypmod,
+									 COERCION_EXPLICIT, COERCE_EXPLICIT_CAST,
+								 	 loc);
+	}
+	else
+		node = coerce_expr(pstate, expr, ityp, otyp, otypmod,
+						   COERCION_EXPLICIT, COERCE_EXPLICIT_CAST, loc);
 	if (node == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_CANNOT_COERCE),
@@ -2266,17 +2275,19 @@ static Node *
 coerce_all_to_jsonb(ParseState *pstate, Node *expr)
 {
 	Oid			type = exprType(expr);
+	TYPCATEGORY tc = TypeCategory(getBaseType(type));
 
-	if (TypeCategory(getBaseType(type)) == TYPCATEGORY_STRING)
+	if (tc == TYPCATEGORY_STRING)
 	{
 		return (Node *) makeFuncExpr(F_CYPHER_TO_JSONB, JSONBOID,
 									 list_make1(expr), InvalidOid,
 									 InvalidOid, COERCE_EXPLICIT_CALL);
 	}
 
-	expr = coerce_expr(pstate, expr, type, JSONBOID, -1,
-					   COERCION_EXPLICIT, COERCE_IMPLICIT_CAST,
-					   exprLocation(expr));
+	if (tc != TYPCATEGORY_USER)
+		expr = coerce_expr(pstate, expr, type, JSONBOID, -1,
+						   COERCION_EXPLICIT, COERCE_IMPLICIT_CAST,
+					   	   exprLocation(expr));
 	Assert(expr != NULL);
 	return expr;
 }
@@ -2608,8 +2619,10 @@ resolveItemList(ParseState *pstate, List *items)
 			is_graph_type(restype) ||
 			type_is_array(restype))
 			continue;
-
-		te->expr = (Expr *) coerce_all_to_jsonb(pstate, (Node *) te->expr);
+		
+		if (!te->resjunk)
+			te->expr = (Expr *) coerce_all_to_jsonb(pstate,
+													(Node *) te->expr);
 	}
 }
 

--- a/src/test/regress/expected/cypher_expr.out
+++ b/src/test/regress/expected/cypher_expr.out
@@ -896,10 +896,50 @@ ERROR:  Variable name "_agens_default_whatever" is not allowed
 LINE 1: MATCH (_agens_default_whatever) RETURN 0;
                ^
 DETAIL:  Variables named "_agens_default_" or starting with "_agens_default_" are reserved for internal use
+-- Test to retain typecast to user-defined datatype
+CREATE (:tc {i: 1, s: 'test', b: true, l: [1, 2, 3], o: {p: 'p'}});
+SELECT pg_typeof(n) FROM (MATCH (n:tc) RETURN n::jsonb::json as n)a;
+ pg_typeof 
+-----------
+ json
+(1 row)
+
+SELECT pg_typeof(n) FROM (RETURN '08:00:2b:01:02:03'::macaddr as n)a;
+ pg_typeof 
+-----------
+ macaddr
+(1 row)
+
+SELECT pg_typeof(n) FROM (MATCH (n:tc) return n.s::tsvector as n)a;
+ pg_typeof 
+-----------
+ tsvector
+(1 row)
+
+EXPLAIN VERBOSE MATCH (n:tc) RETURN n::jsonb::json as n;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Seq Scan on test_cypher_expr.tc n  (cost=0.00..31.00 rows=1200 width=32)
+   Output: ((ROW(n.id, n.properties, n.ctid)::vertex)::jsonb)::json
+(2 rows)
+
+EXPLAIN RETURN '08:00:2b:01:02:03'::macaddr as n;
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=6)
+(1 row)
+
+EXPLAIN VERBOSE MATCH (n:tc) return n.s::tsvector as n;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Seq Scan on test_cypher_expr.tc n  (cost=0.00..22.00 rows=1200 width=32)
+   Output: (n.properties.'s'::text)::tsvector
+(2 rows)
+
 -- Tear down
 DROP TABLE t1;
 DROP GRAPH test_cypher_expr CASCADE;
-NOTICE:  drop cascades to 9 other objects
+NOTICE:  drop cascades to 10 other objects
 DETAIL:  drop cascades to sequence test_cypher_expr.ag_label_seq
 drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
@@ -909,3 +949,4 @@ drop cascades to vlabel v2
 drop cascades to vlabel v3
 drop cascades to vlabel coll
 drop cascades to vlabel ts
+drop cascades to vlabel tc

--- a/src/test/regress/sql/cypher_expr.sql
+++ b/src/test/regress/sql/cypher_expr.sql
@@ -342,6 +342,16 @@ MATCH (_agens_default_) RETURN _agens_default_;
 MATCH (_agens_default_a) RETURN _agens_default_a;
 MATCH (_agens_default_whatever) RETURN 0;
 
+-- Test to retain typecast to user-defined datatype
+CREATE (:tc {i: 1, s: 'test', b: true, l: [1, 2, 3], o: {p: 'p'}});
+SELECT pg_typeof(n) FROM (MATCH (n:tc) RETURN n::jsonb::json as n)a;
+SELECT pg_typeof(n) FROM (RETURN '08:00:2b:01:02:03'::macaddr as n)a;
+SELECT pg_typeof(n) FROM (MATCH (n:tc) return n.s::tsvector as n)a;
+
+EXPLAIN VERBOSE MATCH (n:tc) RETURN n::jsonb::json as n;
+EXPLAIN RETURN '08:00:2b:01:02:03'::macaddr as n;
+EXPLAIN VERBOSE MATCH (n:tc) return n.s::tsvector as n;
+
 -- Tear down
 DROP TABLE t1;
 DROP GRAPH test_cypher_expr CASCADE;


### PR DESCRIPTION
- This helps improve interoperability with other extensions.
- NOTE: this only works for User-defined datatypes at the moment, we may consider changing this to all datatypes in the future. But currently, it is kept to user-defined datatypes to keep the impact minimal while still providing the benefit of interoperability. Existing applications may also get affected if we change this behavior to all datatypes.