### PR TITLE
fix: reject a CALL subquery body that binds one name twice

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -2759,24 +2759,48 @@ transformCypherCallClause(ParseState *pstate, CypherClause *clause)
 										   lateral, true);
 
 	/*
-	 * A CALL subquery may not return a variable already bound in the outer
-	 * query: it would shadow the outer one for the clauses that follow the
-	 * CALL.  Reject the collision -- without this an uncorrelated body
+	 * The names the body returns become bindings in the enclosing query, so
+	 * each one has to resolve to exactly one column.  A name may not already
+	 * be bound in the outer query: it would shadow the outer one for the
+	 * clauses that follow the CALL -- without this an uncorrelated body
 	 * silently shadows the outer variable, while a correlated one fails later
-	 * with a confusing type error.  To return an imported variable the body
-	 * must alias it to a fresh name.
+	 * with a confusing type error.  Nor may the body bind the same name
+	 * twice: a later reference would resolve to the last one by position, so
+	 * reordering the body would silently change the result.  Alias to a fresh
+	 * name to resolve either collision.
+	 *
+	 * The check covers the label the parser gives an unaliased expression,
+	 * "?column?", as well as a written alias: that label is reachable as a
+	 * quoted identifier, so two of them bind a reference just as silently as
+	 * two written names would.  Only a column with no name at all is exempt,
+	 * being unreachable.  The final RETURN of a query still allows duplicates
+	 * -- nothing downstream has to resolve them.
 	 */
 	foreach(lc, nsitem->p_rte->eref->colnames)
 	{
 		char	   *colname = strVal(lfirst(lc));
+		ListCell   *lc2;
 
-		if (colname[0] != '\0' &&
-			nsItemHasColumnNamed(prev_nsitem, colname))
+		if (colname[0] == '\0')
+			continue;
+
+		if (nsItemHasColumnNamed(prev_nsitem, colname))
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_ALIAS),
 					 errmsg("variable \"%s\" returned by the CALL subquery is already bound in the outer query",
 							colname),
 					 parser_errposition(pstate, detail->location)));
+
+		for_each_cell(lc2, nsitem->p_rte->eref->colnames,
+					  lnext(nsitem->p_rte->eref->colnames, lc))
+		{
+			if (strcmp(colname, strVal(lfirst(lc2))) == 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_DUPLICATE_ALIAS),
+						 errmsg("variable \"%s\" is returned more than once by the CALL subquery",
+								colname),
+						 parser_errposition(pstate, detail->location)));
+		}
 	}
 
 	qry->targetList = joinCallBody(pstate, prev_nsitem, nsitem,

--- a/src/test/regress/expected/cypher_call.out
+++ b/src/test/regress/expected/cypher_call.out
@@ -587,6 +587,102 @@ CALL (p) { MATCH (p)-[:HAS_DOG]->(d:Dog) RETURN d.name AS q } RETURN q;
 ERROR:  variable "q" returned by the CALL subquery is already bound in the outer query
 LINE 2: CALL (p) { MATCH (p)-[:HAS_DOG]->(d:Dog) RETURN d.name AS q ...
         ^
+-- 1.7 the body may not bind one name twice ------------------------------------
+-- The names the body returns become bindings in the enclosing query, so each
+-- has to resolve to exactly one column.  Two columns under one name bind a
+-- later reference to the last one by position -- silently, and to the other
+-- one if the body is written in the other order.  WITH and CALL ... YIELD
+-- reject the same state; so does the SQL entry point ("column reference is
+-- ambiguous").
+-- the body binds one name twice
+MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS x } RETURN x;
+                         ^
+-- the two values need not share a type: without the check "x" would be a
+-- string here and a number with the two items written the other way round
+MATCH (p:Person) CALL () { RETURN 1 AS x, 'str' AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1 AS x, 'str' AS x } RETUR...
+                         ^
+MATCH (p:Person) CALL () { RETURN 'str' AS x, 1 AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 'str' AS x, 1 AS x } RETUR...
+                         ^
+-- the duplicate need not be adjacent, and a third one is still one error
+MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS y, 3 AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS y, 3 AS x } R...
+                         ^
+MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS x, 3 AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS x, 3 AS x } R...
+                         ^
+-- a correlated body, where the two values differ per input row
+MATCH (p:Person) CALL (p) { RETURN p.name AS x, p.age AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL (p) { RETURN p.name AS x, p.age AS x }...
+                         ^
+-- an unaliased expression is labelled "?column?", and that label is reachable
+-- as a quoted identifier, so two of them are a duplicate like any other
+MATCH (p:Person) CALL () { RETURN 1, 2 } RETURN "?column?";
+ERROR:  variable "?column?" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1, 2 } RETURN "?column?";
+                         ^
+MATCH (p:Person) CALL () { RETURN 1 + 1, 2 + 2 } RETURN *;
+ERROR:  variable "?column?" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1 + 1, 2 + 2 } RETURN *;
+                         ^
+-- written out as an alias, it is the same name
+MATCH (p:Person) CALL () { RETURN 1 AS "?column?", 2 AS "?column?" } RETURN *;
+ERROR:  variable "?column?" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL () { RETURN 1 AS "?column?", 2 AS "?co...
+                         ^
+-- an importing-WITH body is checked the same way
+MATCH (p:Person) CALL { WITH p RETURN p.name AS x, p.age AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) CALL { WITH p RETURN p.name AS x, p.age AS ...
+                         ^
+-- so is an OPTIONAL CALL body
+MATCH (p:Person) OPTIONAL CALL () { RETURN 1 AS x, 2 AS x } RETURN x;
+ERROR:  variable "x" is returned more than once by the CALL subquery
+LINE 1: MATCH (p:Person) OPTIONAL CALL () { RETURN 1 AS x, 2 AS x } ...
+                                  ^
+-- what the check must not reject.  One unaliased expression is not a
+-- duplicate, and neither is a distinct pair.
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1 } RETURN "?column?";
+ ?column? 
+----------
+ 1
+(1 row)
+
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1, 2 AS z } RETURN *;
+                   p                    | ?column? | z 
+----------------------------------------+----------+---
+ person[3.1]{"age": 36, "name": "Andy"} | 1        | 2
+(1 row)
+
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1 AS x, 2 AS y } RETURN x, y;
+ x | y 
+---+---
+ 1 | 2
+(1 row)
+
+-- the boundary: the final RETURN of a query may repeat a name, because nothing
+-- downstream has to resolve it.  The projection position and the binding
+-- position genuinely differ, and the check belongs only to the latter.
+MATCH (p:Person {name: 'Andy'}) RETURN 1 AS x, 2 AS x;
+ x | x 
+---+---
+ 1 | 2
+(1 row)
+
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1 AS one } RETURN one AS x, 2 AS x;
+ x | x 
+---+---
+ 1 | 2
+(1 row)
+
 --
 -- 2. Nested CALL (a CALL inside another CALL's body)
 --

--- a/src/test/regress/sql/cypher_call.sql
+++ b/src/test/regress/sql/cypher_call.sql
@@ -286,6 +286,48 @@ MATCH (t:Person) CALL () { RETURN 1 AS t } RETURN t;
 MATCH (p:Person {name: 'Andy'}), (q:Person {name: 'Peter'})
 CALL (p) { MATCH (p)-[:HAS_DOG]->(d:Dog) RETURN d.name AS q } RETURN q;
 
+-- 1.7 the body may not bind one name twice ------------------------------------
+
+-- The names the body returns become bindings in the enclosing query, so each
+-- has to resolve to exactly one column.  Two columns under one name bind a
+-- later reference to the last one by position -- silently, and to the other
+-- one if the body is written in the other order.  WITH and CALL ... YIELD
+-- reject the same state; so does the SQL entry point ("column reference is
+-- ambiguous").
+
+-- the body binds one name twice
+MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS x } RETURN x;
+-- the two values need not share a type: without the check "x" would be a
+-- string here and a number with the two items written the other way round
+MATCH (p:Person) CALL () { RETURN 1 AS x, 'str' AS x } RETURN x;
+MATCH (p:Person) CALL () { RETURN 'str' AS x, 1 AS x } RETURN x;
+-- the duplicate need not be adjacent, and a third one is still one error
+MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS y, 3 AS x } RETURN x;
+MATCH (p:Person) CALL () { RETURN 1 AS x, 2 AS x, 3 AS x } RETURN x;
+-- a correlated body, where the two values differ per input row
+MATCH (p:Person) CALL (p) { RETURN p.name AS x, p.age AS x } RETURN x;
+-- an unaliased expression is labelled "?column?", and that label is reachable
+-- as a quoted identifier, so two of them are a duplicate like any other
+MATCH (p:Person) CALL () { RETURN 1, 2 } RETURN "?column?";
+MATCH (p:Person) CALL () { RETURN 1 + 1, 2 + 2 } RETURN *;
+-- written out as an alias, it is the same name
+MATCH (p:Person) CALL () { RETURN 1 AS "?column?", 2 AS "?column?" } RETURN *;
+-- an importing-WITH body is checked the same way
+MATCH (p:Person) CALL { WITH p RETURN p.name AS x, p.age AS x } RETURN x;
+-- so is an OPTIONAL CALL body
+MATCH (p:Person) OPTIONAL CALL () { RETURN 1 AS x, 2 AS x } RETURN x;
+
+-- what the check must not reject.  One unaliased expression is not a
+-- duplicate, and neither is a distinct pair.
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1 } RETURN "?column?";
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1, 2 AS z } RETURN *;
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1 AS x, 2 AS y } RETURN x, y;
+-- the boundary: the final RETURN of a query may repeat a name, because nothing
+-- downstream has to resolve it.  The projection position and the binding
+-- position genuinely differ, and the check belongs only to the latter.
+MATCH (p:Person {name: 'Andy'}) RETURN 1 AS x, 2 AS x;
+MATCH (p:Person {name: 'Andy'}) CALL () { RETURN 1 AS one } RETURN one AS x, 2 AS x;
+
 --
 -- 2. Nested CALL (a CALL inside another CALL's body)
 --


### PR DESCRIPTION
Fixes AGV2-575 — a `CALL` body returning one name twice is now rejected, instead of binding a later reference to whichever came last.

- Adds a rejection: two items under one name, and two or more unaliased items, which share `?column?`. Both were silently ambiguous; aliasing resolves them.
- `cypher_call`: 11 rejected, 5 that must keep working. Reverting the fix fails exactly those 11.
