### PR TITLE
fix: refuse a modifier written after FINISH instead of discarding it

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -100,6 +100,7 @@ static Query *transformCypherClause(ParseState *pstate, CypherClause *clause);
 
 static void preprocess_modifiers(CypherStmt *stmt);
 static bool is_modifier(CypherClause *clause);
+static bool projection_takes_modifiers(CypherClause *clause);
 static bool parent_is_projection(CypherClause *clause);
 static void attach_modifier(CypherClause *clause, CypherClause *modifier);
 static void attach_modifiers_to_projection(CypherClause **clause);
@@ -3824,6 +3825,31 @@ transformCypherStmt(ParseState *pstate, CypherStmt *stmt)
 		case T_CypherSubselectClause:
 			/* a set operation after NEXT produces a table */
 			break;
+		case T_CypherModifier:
+			{
+				CypherClause *prev = (CypherClause *) clause->prev;
+
+				/*
+				 * A modifier run that no projection took is never a valid
+				 * last clause.  ORDER BY / SKIP / LIMIT written after FINISH
+				 * ends up here: name the rule it breaks instead of the
+				 * generic message below.  Modifiers written out of canonical
+				 * order become one clause each, so look past them for the
+				 * FINISH.
+				 */
+				while (prev != NULL &&
+					   cypherClauseTag(prev) == T_CypherModifier)
+					prev = (CypherClause *) prev->prev;
+
+				if (prev != NULL &&
+					cypherClauseTag(prev) == T_CypherProjection &&
+					cypherProjectionKind(prev->detail) == CP_FINISH)
+					ereport(ERROR,
+							(errcode(ERRCODE_SYNTAX_ERROR),
+							 errmsg("FINISH must be at the end of the query")));
+				valid = false;
+				break;
+			}
 		default:
 			valid = false;
 			break;
@@ -3956,6 +3982,40 @@ is_modifier(CypherClause *clause)
 }
 
 /*
+ * projection_takes_modifiers
+ *		Can this clause carry a modifier run folded into it?
+ *
+ *		Only a projection that outputs rows can: its transform reads the ORDER BY
+ *		/ SKIP / LIMIT it is given, so folding one in still analyzes it.  FINISH
+ *		is parsed as a projection too, but it ends the query and returns no rows,
+ *		so its transform has no use for them and would drop them unexamined.
+ *		Leaving the run alone makes it a CypherModifier, which
+ *		transformCypherStmt() then rejects.
+ *
+ *		The kinds that take modifiers are listed rather than excluded, so a kind
+ *		added later refuses the fold -- and is reported -- until it is known to
+ *		read them.
+ */
+static bool
+projection_takes_modifiers(CypherClause *clause)
+{
+	if (cypherClauseTag(clause) != T_CypherProjection)
+		return false;
+
+	switch (cypherProjectionKind(clause->detail))
+	{
+		case CP_RETURN:
+		case CP_WITH:
+		case CP_LET:
+			return true;
+		case CP_FINISH:
+			return false;
+	}
+
+	return false;
+}
+
+/*
  * parent_is_projection
  *		Does the canonical modifier run ending at this clause (ORDER BY, then
  *		SKIP/OFFSET, then LIMIT) sit directly on top of a projection
@@ -3974,15 +4034,15 @@ parent_is_projection(CypherClause *clause)
 	switch (cypherClauseTag(clause))
 	{
 		case T_CypherOrderBy:
-			return cypherClauseTag(prev) == T_CypherProjection;
+			return projection_takes_modifiers(prev);
 		case T_CypherSkip:
-			if (cypherClauseTag(prev) == T_CypherProjection)
+			if (projection_takes_modifiers(prev))
 				return true;
 			if (cypherClauseTag(prev) == T_CypherOrderBy)
 				return parent_is_projection(prev);
 			return false;
 		case T_CypherLimit:
-			if (cypherClauseTag(prev) == T_CypherProjection)
+			if (projection_takes_modifiers(prev))
 				return true;
 			if (cypherClauseTag(prev) == T_CypherOrderBy ||
 				cypherClauseTag(prev) == T_CypherSkip)

--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -1110,6 +1110,14 @@ transformCypherProjection(ParseState *pstate, CypherClause *clause)
 	{
 		ParseNamespaceItem *prev_nsitem = NULL;
 
+		/*
+		 * FINISH returns no rows, so it carries no ORDER BY / SKIP / LIMIT:
+		 * preprocess_modifiers() does not fold one into it and
+		 * transformCypherStmt() rejects one written after it.
+		 */
+		Assert(detail->order == NIL && detail->skip == NULL &&
+			   detail->limit == NULL);
+
 		if (clause->prev != NULL)
 			prev_nsitem = transformClause(pstate, clause->prev);
 

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -369,6 +369,47 @@ MATCH (:person)-[r:knows]->(:person) RETURN count(r) AS knows;
 -- FINISH must be the last clause
 MATCH (n) FINISH RETURN n;
 ERROR:  FINISH must be at the end of the query
+-- ORDER BY / SKIP / OFFSET / LIMIT are clauses in their own right, so they are
+-- rejected after FINISH as well, in canonical order or not
+MATCH (n) FINISH ORDER BY 1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n) FINISH SKIP 1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n) FINISH OFFSET 1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n) FINISH LIMIT 1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n) FINISH ORDER BY n.name SKIP 1 LIMIT 1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n) FINISH LIMIT 1 ORDER BY n.name;
+ERROR:  FINISH must be at the end of the query
+-- arguments that are errors on their own are rejected here as misplaced
+-- clauses: they used to reach no analysis at all
+MATCH (n) FINISH LIMIT -1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n) FINISH ORDER BY nosuchvar;
+ERROR:  FINISH must be at the end of the query
+-- and the query is rejected before a write in it takes effect
+MATCH (n:person {name: 'A'}) CREATE (:person {name: 'H'}) FINISH LIMIT 1;
+ERROR:  FINISH must be at the end of the query
+MATCH (n:person {name: 'H'}) RETURN count(n) AS unwritten;
+ unwritten 
+-----------
+ 0
+(1 row)
+
+-- modifiers before FINISH still page the query FINISH ends
+MATCH (n) ORDER BY n.name LIMIT 1 FINISH;
+--
+(0 rows)
+
+MATCH (n) ORDER BY n.name LIMIT 1 CREATE (:person {name: 'I'}) FINISH;
+MATCH (n:person {name: 'I'}) RETURN count(n) AS written;
+ written 
+---------
+ 1
+(1 row)
+
 -- plan structure: a read + FINISH applies LIMIT 0; a write + FINISH runs the write
 EXPLAIN (COSTS OFF) MATCH (n) FINISH;
               QUERY PLAN               

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -196,6 +196,29 @@ MATCH (:person)-[r:knows]->(:person) RETURN count(r) AS knows;
 -- FINISH must be the last clause
 MATCH (n) FINISH RETURN n;
 
+-- ORDER BY / SKIP / OFFSET / LIMIT are clauses in their own right, so they are
+-- rejected after FINISH as well, in canonical order or not
+MATCH (n) FINISH ORDER BY 1;
+MATCH (n) FINISH SKIP 1;
+MATCH (n) FINISH OFFSET 1;
+MATCH (n) FINISH LIMIT 1;
+MATCH (n) FINISH ORDER BY n.name SKIP 1 LIMIT 1;
+MATCH (n) FINISH LIMIT 1 ORDER BY n.name;
+
+-- arguments that are errors on their own are rejected here as misplaced
+-- clauses: they used to reach no analysis at all
+MATCH (n) FINISH LIMIT -1;
+MATCH (n) FINISH ORDER BY nosuchvar;
+
+-- and the query is rejected before a write in it takes effect
+MATCH (n:person {name: 'A'}) CREATE (:person {name: 'H'}) FINISH LIMIT 1;
+MATCH (n:person {name: 'H'}) RETURN count(n) AS unwritten;
+
+-- modifiers before FINISH still page the query FINISH ends
+MATCH (n) ORDER BY n.name LIMIT 1 FINISH;
+MATCH (n) ORDER BY n.name LIMIT 1 CREATE (:person {name: 'I'}) FINISH;
+MATCH (n:person {name: 'I'}) RETURN count(n) AS written;
+
 -- plan structure: a read + FINISH applies LIMIT 0; a write + FINISH runs the write
 EXPLAIN (COSTS OFF) MATCH (n) FINISH;
 EXPLAIN (COSTS OFF) CREATE (:person {name: 'G'}) FINISH;


### PR DESCRIPTION
Fixes AGV2-577 — `ORDER BY` / `SKIP` / `LIMIT` after `FINISH` are now refused with the documented error, instead of being discarded unexamined.

- Adds a rejection, but `FINISH` has never shipped: added 2026-06-24, latest tag `v2.17.0`.
- Regression 21/21. Negative control fails exactly the 8 new cases.
- AGV2-576 is stacked on this branch and waits for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
