### PR TITLE
fix: give a cast property a collation so it can be ordered and grouped

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -1138,7 +1138,7 @@ exprCollation(const Node *expr)
 
 			/* Agensgraph cases below */
 		case T_CypherTypeCast:
-			coll = InvalidOid;
+			coll = ((const CypherTypeCast *) expr)->resultcollid;
 			break;
 		case T_CypherMapExpr:
 			coll = InvalidOid;
@@ -1406,7 +1406,7 @@ exprSetCollation(Node *expr, Oid collation)
 
 			/* Agensgraph cases below */
 		case T_CypherTypeCast:
-			/* XXX: Don't care for now */
+			((CypherTypeCast *) expr)->resultcollid = collation;
 			break;
 		case T_CypherMapExpr:
 			Assert(!OidIsValid(collation));

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -3730,12 +3730,14 @@ eval_const_expressions_mutator(Node *node,
 				newtc->cctx = tc->cctx;
 				newtc->cform = tc->cform;
 				newtc->typcategory = tc->typcategory;
+				newtc->resultcollid = tc->resultcollid;
 				newtc->arg = (Expr *) newarg;
 				newtc->location = tc->location;
 
 				if (IsA(newarg, Const))
 					return (Node *) evaluate_expr((Expr *) newtc, newtc->type,
-												  newtc->typmod, InvalidOid);
+												  newtc->typmod,
+												  newtc->resultcollid);
 
 				return (Node *) newtc;
 			}

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -2387,6 +2387,8 @@ typedef struct CypherTypeCast
 	CoercionContext cctx;
 	CoercionForm cform;
 	char		typcategory;
+	/* OID of collation, or InvalidOid if none */
+	Oid			resultcollid pg_node_attr(query_jumble_ignore);
 	Expr	   *arg;
 	ParseLoc	location;
 } CypherTypeCast;

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -11123,6 +11123,119 @@ RETURN DISTINCT (n.name #>> '{}') AS nm, (n.city #>> '{}') AS ct ORDER BY ct, nm
  "bob" | "rome"
 (5 rows)
 
+-- The cast spelling of the same extraction -- n.prop::text -- must behave
+-- identically.  It reaches the same uncollated text through CypherTypeCast, the
+-- one Cypher node whose result can be collatable, so it needs the same default
+-- collation on a comparison, sort or hash key.  (A terminal RETURN's DISTINCT /
+-- GROUP BY happened to escape the failure by boxing its keys back to jsonb; a
+-- non-terminal WITH has no such boxing, so both stages are covered here.)
+-- ORDER BY on the cast, incl. the NULL
+MATCH (n:person) RETURN n.name::text AS nm ORDER BY nm NULLS FIRST;
+  nm   
+-------
+ 
+ "amy"
+ "bob"
+ "bob"
+ "cat"
+(5 rows)
+
+-- the cast is only the sort key -- it is not projected
+MATCH (n:person) RETURN n.name AS nm ORDER BY n.name::text NULLS FIRST;
+  nm   
+-------
+ 
+ "amy"
+ "bob"
+ "bob"
+ "cat"
+(5 rows)
+
+-- a non-terminal WITH that orders by the cast
+MATCH (n:person) WITH n.name::text AS nm ORDER BY nm NULLS FIRST RETURN nm;
+  nm   
+-------
+ 
+ "amy"
+ "bob"
+ "bob"
+ "cat"
+(5 rows)
+
+-- WITH DISTINCT over the cast: a hash key, not a sort key
+MATCH (n:person) WITH DISTINCT n.name::text AS nm RETURN nm ORDER BY nm NULLS FIRST;
+  nm   
+-------
+ 
+ "amy"
+ "bob"
+ "cat"
+(4 rows)
+
+-- a WITH-stage implicit GROUP BY whose key is the cast
+MATCH (n:person) WITH n.name::text AS nm, count(*) AS c ORDER BY nm NULLS FIRST RETURN nm, c;
+  nm   | c 
+-------+---
+       | 1
+ "amy" | 1
+ "bob" | 2
+ "cat" | 1
+(4 rows)
+
+-- terminal RETURN DISTINCT and an implicit GROUP BY on two cast keys
+MATCH (n:person) RETURN DISTINCT n.name::text AS nm ORDER BY nm NULLS FIRST;
+  nm   
+-------
+ 
+ "amy"
+ "bob"
+ "cat"
+(4 rows)
+
+MATCH (n:person)
+RETURN n.name::text AS nm, n.city::text AS ct, count(*) AS c
+ORDER BY nm NULLS FIRST, ct;
+  nm   |   ct   | c 
+-------+--------+---
+       | "oslo" | 1
+ "amy" | "rome" | 1
+ "bob" | "oslo" | 1
+ "bob" | "rome" | 1
+ "cat" | "oslo" | 1
+(5 rows)
+
+-- min()/max() over the cast -- these already worked, and must keep working
+MATCH (n:person) RETURN min(n.name::text) AS lo, max(n.name::text) AS hi;
+  lo   |  hi   
+-------+-------
+ "amy" | "cat"
+(1 row)
+
+-- a cast boxed back to jsonb: the outer cast folds away, leaving the text as the
+-- sort key, so this is the same case and not a workaround
+MATCH (n:person) RETURN n.name::text::jsonb AS nm ORDER BY nm NULLS FIRST;
+  nm   
+-------
+ 
+ "amy"
+ "bob"
+ "bob"
+ "cat"
+(5 rows)
+
+-- a cast of a literal folds to a Const.  A constant key is eliminated before
+-- any comparison, so this shape does not fail for want of a collation; it
+-- guards the fold path itself -- the rebuilt node must keep its fields.
+MATCH (n:person)
+RETURN DISTINCT n.name::text AS nm, 'lit'::text AS w ORDER BY nm NULLS FIRST, w;
+  nm   |   w   
+-------+-------
+       | "lit"
+ "amy" | "lit"
+ "bob" | "lit"
+ "cat" | "lit"
+(4 rows)
+
 DROP GRAPH collate_jsonb CASCADE;
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to sequence collate_jsonb.ag_label_seq

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -4208,6 +4208,37 @@ RETURN collect(DISTINCT (n.name #>> '{}')) AS names, count(DISTINCT (n.city #>> 
 -- DISTINCT on two extracted-text keys with a compound ORDER BY
 MATCH (n:person)
 RETURN DISTINCT (n.name #>> '{}') AS nm, (n.city #>> '{}') AS ct ORDER BY ct, nm NULLS LAST;
+-- The cast spelling of the same extraction -- n.prop::text -- must behave
+-- identically.  It reaches the same uncollated text through CypherTypeCast, the
+-- one Cypher node whose result can be collatable, so it needs the same default
+-- collation on a comparison, sort or hash key.  (A terminal RETURN's DISTINCT /
+-- GROUP BY happened to escape the failure by boxing its keys back to jsonb; a
+-- non-terminal WITH has no such boxing, so both stages are covered here.)
+-- ORDER BY on the cast, incl. the NULL
+MATCH (n:person) RETURN n.name::text AS nm ORDER BY nm NULLS FIRST;
+-- the cast is only the sort key -- it is not projected
+MATCH (n:person) RETURN n.name AS nm ORDER BY n.name::text NULLS FIRST;
+-- a non-terminal WITH that orders by the cast
+MATCH (n:person) WITH n.name::text AS nm ORDER BY nm NULLS FIRST RETURN nm;
+-- WITH DISTINCT over the cast: a hash key, not a sort key
+MATCH (n:person) WITH DISTINCT n.name::text AS nm RETURN nm ORDER BY nm NULLS FIRST;
+-- a WITH-stage implicit GROUP BY whose key is the cast
+MATCH (n:person) WITH n.name::text AS nm, count(*) AS c ORDER BY nm NULLS FIRST RETURN nm, c;
+-- terminal RETURN DISTINCT and an implicit GROUP BY on two cast keys
+MATCH (n:person) RETURN DISTINCT n.name::text AS nm ORDER BY nm NULLS FIRST;
+MATCH (n:person)
+RETURN n.name::text AS nm, n.city::text AS ct, count(*) AS c
+ORDER BY nm NULLS FIRST, ct;
+-- min()/max() over the cast -- these already worked, and must keep working
+MATCH (n:person) RETURN min(n.name::text) AS lo, max(n.name::text) AS hi;
+-- a cast boxed back to jsonb: the outer cast folds away, leaving the text as the
+-- sort key, so this is the same case and not a workaround
+MATCH (n:person) RETURN n.name::text::jsonb AS nm ORDER BY nm NULLS FIRST;
+-- a cast of a literal folds to a Const.  A constant key is eliminated before
+-- any comparison, so this shape does not fail for want of a collation; it
+-- guards the fold path itself -- the rebuilt node must keep its fields.
+MATCH (n:person)
+RETURN DISTINCT n.name::text AS nm, 'lit'::text AS w ORDER BY nm NULLS FIRST, w;
 DROP GRAPH collate_jsonb CASCADE;
 --
 -- A terminal write carries only the elements it names


### PR DESCRIPTION
Fixes AGV2-581 — `n.prop::text` can now be an `ORDER BY`, `DISTINCT` or `GROUP BY` key instead of failing for want of a collation.

- **Decide: `CATALOG_VERSION_NO`.** Left alone, following the last two field additions to a Cypher node (`216ff4f678`, `557064689c`). Copilot's review says bump it.
- **Operational:** a property index on a cast needs `DROP`+`CREATE`; `REINDEX` keeps the stale `indcollation`, and a mismatch is ignored silently.
- Regression 252/252, no existing expected output moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
