### PR TITLE
fix: finish a write clause however many of its rows the plan reads

### DIFF
--- a/src/backend/executor/nodeModifyGraph.c
+++ b/src/backend/executor/nodeModifyGraph.c
@@ -255,6 +255,16 @@ ExecInitModifyGraph(ModifyGraph *mgplan, EState *estate, int eflags)
 	}
 
 	initGraphWRStats(mgstate, mgplan->operation);
+
+	/*
+	 * A write clause that is not the last clause is run to completion by
+	 * ExecPostprocessPlan at ExecutorFinish, however many of its rows the
+	 * plan above it read.  Later clauses are listed first and finished first.
+	 */
+	if (!mgplan->last)
+		estate->es_auxmodifytables = lcons(mgstate,
+										   estate->es_auxmodifytables);
+
 	return mgstate;
 }
 

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -11995,3 +11995,157 @@ drop cascades to elabel t4
 drop cascades to vlabel p
 drop cascades to elabel e
 RESET graph_path;
+-- a write clause runs to completion however many of its rows the plan above
+-- it reads
+CREATE GRAPH write_done;
+SET graph_path = write_done;
+CREATE (:src {i: 1}), (:src {i: 2}), (:src {i: 3}), (:src {i: 4}), (:src {i: 5});
+CREATE VLABEL empty;
+-- a LIMIT above the write returns that many rows and writes every input row
+MATCH (a:src) CREATE (:w1) RETURN 1 AS r LIMIT 1;
+ r 
+---
+ 1
+(1 row)
+
+MATCH (n:w1) RETURN count(*) AS w1_written;
+ w1_written 
+------------
+ 5
+(1 row)
+
+MATCH (a:src) CREATE (:w2) RETURN 1 AS r LIMIT 0;
+ r 
+---
+(0 rows)
+
+MATCH (n:w2) RETURN count(*) AS w2_written;
+ w2_written 
+------------
+ 5
+(1 row)
+
+MATCH (a:src) CREATE (:w3) RETURN 1 AS r SKIP 4;
+ r 
+---
+ 1
+(1 row)
+
+MATCH (n:w3) RETURN count(*) AS w3_written;
+ w3_written 
+------------
+ 5
+(1 row)
+
+MATCH (a:src) MERGE (:w4 {i: a.i}) RETURN 1 AS r LIMIT 1;
+ r 
+---
+ 1
+(1 row)
+
+MATCH (n:w4) RETURN count(*) AS w4_written;
+ w4_written 
+------------
+ 5
+(1 row)
+
+MATCH (a:src) INSERT (:w5) RETURN 1 AS r LIMIT 1;
+ r 
+---
+ 1
+(1 row)
+
+MATCH (n:w5) RETURN count(*) AS w5_written;
+ w5_written 
+------------
+ 5
+(1 row)
+
+MATCH (a:src) CREATE (:w6b) CREATE (:w6c) RETURN 1 AS r LIMIT 1;
+ r 
+---
+ 1
+(1 row)
+
+MATCH (b:w6b) WITH count(b) AS w6b_written MATCH (c:w6c)
+RETURN w6b_written, count(c) AS w6c_written;
+ w6b_written | w6c_written 
+-------------+-------------
+ 5           | 5
+(1 row)
+
+MATCH (a:src) CREATE (m:w7) WITH m LIMIT 2 RETURN count(*) AS rows_after_limit;
+ rows_after_limit 
+------------------
+ 2
+(1 row)
+
+MATCH (n:w7) RETURN count(*) AS w7_written;
+ w7_written 
+------------
+ 5
+(1 row)
+
+MATCH (a:src) SET a.s = 1 RETURN 1 AS r LIMIT 1;
+ r 
+---
+ 1
+(1 row)
+
+MATCH (a:src) RETURN count(a.s) AS src_set;
+ src_set 
+---------
+ 5
+(1 row)
+
+-- a hash join with an empty build side reads one probe row and stops; the
+-- write on the probe side still runs for every input row
+SET enable_mergejoin = off;
+SET enable_nestloop = off;
+EXPLAIN (COSTS OFF)
+MATCH (a:src) CREATE (m:w8 {i: a.i}) WITH m MATCH (b:empty) WHERE b.i = m.i
+RETURN count(*) AS rows_joined;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Aggregate
+   ->  Hash Join
+         Hash Cond: ((_agens_default_s.m).properties.'i' = b.properties.'i')
+         ->  Subquery Scan on _agens_default_s
+               ->  Graph Create
+                     ->  Seq Scan on src a
+         ->  Hash
+               ->  Seq Scan on empty b
+(8 rows)
+
+MATCH (a:src) CREATE (m:w8 {i: a.i}) WITH m MATCH (b:empty) WHERE b.i = m.i
+RETURN count(*) AS rows_joined;
+ rows_joined 
+-------------
+ 0
+(1 row)
+
+RESET enable_mergejoin;
+RESET enable_nestloop;
+MATCH (n:w8) RETURN count(*) AS w8_written;
+ w8_written 
+------------
+ 5
+(1 row)
+
+DROP GRAPH write_done CASCADE;
+NOTICE:  drop cascades to 14 other objects
+DETAIL:  drop cascades to sequence write_done.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel src
+drop cascades to vlabel empty
+drop cascades to vlabel w1
+drop cascades to vlabel w2
+drop cascades to vlabel w3
+drop cascades to vlabel w4
+drop cascades to vlabel w5
+drop cascades to vlabel w6b
+drop cascades to vlabel w6c
+drop cascades to vlabel w7
+drop cascades to vlabel w8
+RESET graph_path;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -4657,3 +4657,45 @@ MATCH (s:P) WHERE EXISTS { MATCH (s)-[:E*1..2]->() } RETURN s.k ORDER BY s.k;
 
 DROP GRAPH vle_rescan CASCADE;
 RESET graph_path;
+
+-- a write clause runs to completion however many of its rows the plan above
+-- it reads
+CREATE GRAPH write_done;
+SET graph_path = write_done;
+CREATE (:src {i: 1}), (:src {i: 2}), (:src {i: 3}), (:src {i: 4}), (:src {i: 5});
+CREATE VLABEL empty;
+
+-- a LIMIT above the write returns that many rows and writes every input row
+MATCH (a:src) CREATE (:w1) RETURN 1 AS r LIMIT 1;
+MATCH (n:w1) RETURN count(*) AS w1_written;
+MATCH (a:src) CREATE (:w2) RETURN 1 AS r LIMIT 0;
+MATCH (n:w2) RETURN count(*) AS w2_written;
+MATCH (a:src) CREATE (:w3) RETURN 1 AS r SKIP 4;
+MATCH (n:w3) RETURN count(*) AS w3_written;
+MATCH (a:src) MERGE (:w4 {i: a.i}) RETURN 1 AS r LIMIT 1;
+MATCH (n:w4) RETURN count(*) AS w4_written;
+MATCH (a:src) INSERT (:w5) RETURN 1 AS r LIMIT 1;
+MATCH (n:w5) RETURN count(*) AS w5_written;
+MATCH (a:src) CREATE (:w6b) CREATE (:w6c) RETURN 1 AS r LIMIT 1;
+MATCH (b:w6b) WITH count(b) AS w6b_written MATCH (c:w6c)
+RETURN w6b_written, count(c) AS w6c_written;
+MATCH (a:src) CREATE (m:w7) WITH m LIMIT 2 RETURN count(*) AS rows_after_limit;
+MATCH (n:w7) RETURN count(*) AS w7_written;
+MATCH (a:src) SET a.s = 1 RETURN 1 AS r LIMIT 1;
+MATCH (a:src) RETURN count(a.s) AS src_set;
+
+-- a hash join with an empty build side reads one probe row and stops; the
+-- write on the probe side still runs for every input row
+SET enable_mergejoin = off;
+SET enable_nestloop = off;
+EXPLAIN (COSTS OFF)
+MATCH (a:src) CREATE (m:w8 {i: a.i}) WITH m MATCH (b:empty) WHERE b.i = m.i
+RETURN count(*) AS rows_joined;
+MATCH (a:src) CREATE (m:w8 {i: a.i}) WITH m MATCH (b:empty) WHERE b.i = m.i
+RETURN count(*) AS rows_joined;
+RESET enable_mergejoin;
+RESET enable_nestloop;
+MATCH (n:w8) RETURN count(*) AS w8_written;
+
+DROP GRAPH write_done CASCADE;
+RESET graph_path;


### PR DESCRIPTION
Fixes AGV2-578
#note A write clause now runs to completion at ExecutorFinish, so a LIMIT or a join above it no longer loses writes. #devdone

A write clause streams its rows and performs each row's write when the plan above it pulls that row.  A LIMIT above a CREATE, MERGE or INSERT stopped pulling after the limit, and the rows past it were never written: MATCH (a) CREATE (m) RETURN m LIMIT 1 wrote one node for five input rows, LIMIT 0 wrote none, and two chained writes lost rows in both.  A hash join with an empty build side reads one probe row and stops, so a write on the probe side wrote one node with no LIMIT in the statement.  SET and DELETE were not affected because they run eagerly.  The statement reported no error.

A write clause that is not the last clause is now listed in es_auxmodifytables, so ExecPostprocessPlan runs it to completion at ExecutorFinish, before AFTER triggers, the way a data-modifying CTE is. The rows the plan asked for are still streamed; the rest are written when the plan is done.  Plans are unchanged.