### PR TITLE
fix: collect nodes, relationships and paths from a subquery natively

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -211,6 +211,7 @@ static void preprocess_pubobj_list(List *pubobjspec_list,
 static Node *makeRecursiveViewSelect(char *relname, List *aliases, Node *query);
 
 static Node *makeCypherSetOp(SetOperation op, bool all, Node *larg, Node *rarg);
+static Node *makeCypherGenericExpr(Node *expr);
 static Node *makeCypherNext(Node *left, Node *right);
 static Node *makeCypherProjection(CPKind kind, List *distinct, List *items,
 								  Node *where);
@@ -23001,10 +23002,10 @@ cypher_count_subquery:
 
 /*
  * COLLECT subquery: every value the single-column read subquery yields,
- * gathered into a cypher list (a jsonb array) -- order-preserving and
- * NULL-preserving, and [] (never NULL) when the subquery is empty.  Built as
- * a native ARRAY_SUBLINK whose SQL array is coerced to jsonb through the
- * standard cypher_to_jsonb path, yielding a first-class cypher list.
+ * gathered into a cypher list -- order-preserving and NULL-preserving, and []
+ * (never NULL) when the subquery is empty.  Built as a native ARRAY_SUBLINK
+ * wrapped as a Cypher expression; the transform boxes the array to jsonb
+ * unless it holds nodes, relationships or paths, which stay a list of those.
  */
 cypher_collect_subquery:
 			COLLECT '{' cypher_read_stmt '}'
@@ -23018,7 +23019,7 @@ cypher_collect_subquery:
 					n->operName = NIL;
 					n->subselect = $3;
 					n->location = @1;
-					$$ = makeTypeCast((Node *) n, SystemTypeName("jsonb"), @1);
+					$$ = makeCypherGenericExpr((Node *) n);
 				}
 			| COLLECT '{' select_no_parens '}'
 				{
@@ -23031,15 +23032,15 @@ cypher_collect_subquery:
 					n->operName = NIL;
 					n->subselect = $3;
 					n->location = @1;
-					$$ = makeTypeCast((Node *) n, SystemTypeName("jsonb"), @1);
+					$$ = makeCypherGenericExpr((Node *) n);
 				}
 		;
 
 /*
  * ARRAY subquery: the SQL/GQL-standard spelling of COLLECT -- every value the
- * single-column read subquery yields, gathered into a cypher list (a jsonb
- * array): order-preserving, NULL-preserving, and [] (never NULL) when empty.
- * Built, like COLLECT, as a native ARRAY_SUBLINK coerced to jsonb.
+ * single-column read subquery yields, gathered into a cypher list:
+ * order-preserving, NULL-preserving, and [] (never NULL) when empty.  Built,
+ * like COLLECT, as a wrapped ARRAY_SUBLINK that the transform boxes.
  */
 cypher_array_subquery:
 			ARRAY '{' cypher_read_stmt '}'
@@ -23053,7 +23054,7 @@ cypher_array_subquery:
 					n->operName = NIL;
 					n->subselect = $3;
 					n->location = @1;
-					$$ = makeTypeCast((Node *) n, SystemTypeName("jsonb"), @1);
+					$$ = makeCypherGenericExpr((Node *) n);
 				}
 			| ARRAY '{' select_no_parens '}'
 				{
@@ -23066,7 +23067,7 @@ cypher_array_subquery:
 					n->operName = NIL;
 					n->subselect = $3;
 					n->location = @1;
-					$$ = makeTypeCast((Node *) n, SystemTypeName("jsonb"), @1);
+					$$ = makeCypherGenericExpr((Node *) n);
 				}
 		;
 
@@ -24192,6 +24193,16 @@ makeCypherProjection(CPKind kind, List *distinct, List *items, Node *where)
 	n->skip = NULL;
 	n->limit = NULL;
 	n->where = where;
+
+	return (Node *) n;
+}
+
+static Node *
+makeCypherGenericExpr(Node *expr)
+{
+	CypherGenericExpr *n = makeNode(CypherGenericExpr);
+
+	n->expr = expr;
 
 	return (Node *) n;
 }

--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -62,6 +62,7 @@ static Node *transformFields(ParseState *pstate, Node *basenode, List *fields,
 							 int location);
 static Node *transformParamRef(ParseState *pstate, ParamRef *pref);
 static Node *transformTypeCast(ParseState *pstate, TypeCast *tc);
+static Oid	graphElementArrayType(Oid elemtype);
 static Node *transformCypherMapExpr(ParseState *pstate, CypherMapExpr *m);
 static Node *transformCypherListExpr(ParseState *pstate, CypherListExpr *cl);
 static Node *transformCypherListComp(ParseState *pstate, CypherListComp *clc);
@@ -168,17 +169,38 @@ transformCypherExprRecurse(ParseState *pstate, Node *expr)
 			return transformFuncCall(pstate, (FuncCall *) expr);
 		case T_CoalesceExpr:
 			return transformCoalesceExpr(pstate, (CoalesceExpr *) expr);
+		case T_CypherGenericExpr:
+			return transformCypherExprRecurse(pstate,
+											  ((CypherGenericExpr *) expr)->expr);
 		case T_SubLink:
 			{
 				SubLink    *sublink = (SubLink *) expr;
 				CypherGenericExpr *cexpr;
+				Node	   *node;
 
 				cexpr = makeNode(CypherGenericExpr);
 				cexpr->expr = sublink->testexpr;
 
 				sublink->testexpr = (Node *) cexpr;
 
-				return transformExpr(pstate, expr, pstate->p_expr_kind);
+				node = transformExpr(pstate, expr, pstate->p_expr_kind);
+
+				/*
+				 * COLLECT { } and ARRAY { } gather the body's column into a
+				 * list.  A list of nodes, relationships or paths is kept as
+				 * their array; any other list is boxed to jsonb.
+				 */
+				if (sublink->subLinkType == ARRAY_SUBLINK)
+				{
+					Oid			type = exprType(node);
+
+					if (!OidIsValid(graphElementArrayType(get_element_type(type))))
+						node = coerce_expr(pstate, node, type, JSONBOID, -1,
+										   COERCION_EXPLICIT, COERCE_EXPLICIT_CAST,
+										   exprLocation(node));
+				}
+
+				return node;
 			}
 		case T_A_Indirection:
 			return transformIndirection(pstate, (A_Indirection *) expr);
@@ -2943,7 +2965,12 @@ transformAExprIn(ParseState *pstate, A_Expr *a)
 					if (rtype == JSONBOID || type_is_array(rtype) || rtype == ANYARRAYOID)
 					{
 						/* Coerce anyarray to jsonb for containment operator */
-						if (rtype == ANYARRAYOID || type_is_array(rtype))
+						if (is_graph_type(rtype))
+							rexpr = (Node *) makeFuncExpr(F_TO_JSONB, JSONBOID,
+														  list_make1(rexpr),
+														  InvalidOid, InvalidOid,
+														  COERCE_EXPLICIT_CALL);
+						else if (rtype == ANYARRAYOID || type_is_array(rtype))
 							rexpr = coerce_to_jsonb(pstate, rexpr, "list");
 
 						result = (Node *) make_op(pstate, list_make1(makeString("@>")),

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -9454,6 +9454,97 @@ RETURN s.dogs AS dogs;
  ["Andy", "Fido", "Ozzy"]
 (1 row)
 
+-- a COLLECT or ARRAY of nodes, relationships or paths is a list of those
+RETURN COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name } AS dogs;
+                                     dogs                                     
+------------------------------------------------------------------------------
+ [dog[5.1]{"name": "Andy"},dog[5.2]{"name": "Fido"},dog[5.3]{"name": "Ozzy"}]
+(1 row)
+
+RETURN ARRAY { MATCH (d:Dog) RETURN d ORDER BY d.name } AS dogs;
+                                     dogs                                     
+------------------------------------------------------------------------------
+ [dog[5.1]{"name": "Andy"},dog[5.2]{"name": "Fido"},dog[5.3]{"name": "Ozzy"}]
+(1 row)
+
+RETURN head(COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name }).name AS first_dog;
+ first_dog 
+-----------
+ "Andy"
+(1 row)
+
+RETURN keys(head(COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name })) AS first_keys;
+ first_keys 
+------------
+ ["name"]
+(1 row)
+
+RETURN label(head(COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name })) AS first_label;
+ first_label 
+-------------
+ "dog"
+(1 row)
+
+RETURN [x IN COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name } | x.name] AS names;
+          names           
+--------------------------
+ ["Andy", "Fido", "Ozzy"]
+(1 row)
+
+RETURN COLLECT { MATCH (:Person)-[r:HAS_DOG]->(:Dog) RETURN r ORDER BY id(r) } AS owns;
+                                   owns                                    
+---------------------------------------------------------------------------
+ [has_dog[4.1][3.1,5.1]{},has_dog[4.2][3.3,5.2]{},has_dog[4.3][3.3,5.3]{}]
+(1 row)
+
+RETURN length(head(COLLECT { MATCH p = (q:Person)-[:HAS_DOG]->(d:Dog)
+                             RETURN p ORDER BY q.name, d.name })) AS hops;
+ hops 
+------
+ 1
+(1 row)
+
+RETURN COLLECT { MATCH (d:Dog) WHERE d.name = 'nobody' RETURN d } AS none;
+ none 
+------
+ []
+(1 row)
+
+-- a property list is still a jsonb list
+RETURN COLLECT { MATCH (d:Dog) RETURN d.name ORDER BY d.name } AS names;
+          names           
+--------------------------
+ ["Andy", "Fido", "Ozzy"]
+(1 row)
+
+-- membership in a collected element list is a test of identity
+MATCH (a:Dog), (b:Dog) WHERE id(a) <> id(b)
+RETURN a.name AS a, b.name AS b,
+       a IN COLLECT { MATCH (d:Dog) WHERE id(d) = id(b) RETURN d } AS in_other,
+       a IN COLLECT { MATCH (d:Dog) WHERE id(d) = id(a) RETURN d } AS in_self
+ORDER BY a, b;
+   a    |   b    | in_other | in_self 
+--------+--------+----------+---------
+ "Andy" | "Fido" | f        | t
+ "Andy" | "Ozzy" | f        | t
+ "Fido" | "Andy" | f        | t
+ "Fido" | "Ozzy" | f        | t
+ "Ozzy" | "Andy" | f        | t
+ "Ozzy" | "Fido" | f        | t
+(6 rows)
+
+-- a scalar is never a member of an element list
+RETURN 1 IN COLLECT { MATCH (d:Dog) RETURN d } AS r;
+ r 
+---
+ f
+(1 row)
+
+-- error: a property cannot hold a list of nodes
+MATCH (p:Person) WITH p LIMIT 1 SET p.dogs = COLLECT { MATCH (d:Dog) RETURN d };
+ERROR:  property cannot hold vertex[]
+LINE 1: MATCH (p:Person) WITH p LIMIT 1 SET p.dogs = COLLECT { MATCH...
+                                                     ^
 -- error: the subquery must return exactly one column (Cypher form)
 RETURN COLLECT { MATCH (p:Person)-[:HAS_DOG]->(d:Dog) RETURN p.name, d.name };
 ERROR:  subquery must return only one column
@@ -11732,11 +11823,11 @@ EXPLAIN (COSTS OFF) MATCH (a:v {k: 7})-[:e*2..2]-(b:v) RETURN count(*);
 -----------------------------------------------------------
  Aggregate
    ->  Hash Join
-         Hash Cond: ("<0000000799>"._end = b.id)
+         Hash Cond: ("<0000000802>"._end = b.id)
          ->  Nested Loop
                ->  Seq Scan on v a
                      Filter: (properties.'k' = '7'::jsonb)
-               ->  Subquery Scan on "<0000000799>"
+               ->  Subquery Scan on "<0000000802>"
                      ->  Graph VLE on e [2..2]
                            ->  Result
          ->  Hash

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -3485,6 +3485,30 @@ RETURN person.dogNames AS dogNames;
 CREATE (s:Summary {dogs: COLLECT { MATCH (d:Dog) RETURN d.name ORDER BY d.name }})
 RETURN s.dogs AS dogs;
 
+-- a COLLECT or ARRAY of nodes, relationships or paths is a list of those
+RETURN COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name } AS dogs;
+RETURN ARRAY { MATCH (d:Dog) RETURN d ORDER BY d.name } AS dogs;
+RETURN head(COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name }).name AS first_dog;
+RETURN keys(head(COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name })) AS first_keys;
+RETURN label(head(COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name })) AS first_label;
+RETURN [x IN COLLECT { MATCH (d:Dog) RETURN d ORDER BY d.name } | x.name] AS names;
+RETURN COLLECT { MATCH (:Person)-[r:HAS_DOG]->(:Dog) RETURN r ORDER BY id(r) } AS owns;
+RETURN length(head(COLLECT { MATCH p = (q:Person)-[:HAS_DOG]->(d:Dog)
+                             RETURN p ORDER BY q.name, d.name })) AS hops;
+RETURN COLLECT { MATCH (d:Dog) WHERE d.name = 'nobody' RETURN d } AS none;
+-- a property list is still a jsonb list
+RETURN COLLECT { MATCH (d:Dog) RETURN d.name ORDER BY d.name } AS names;
+-- membership in a collected element list is a test of identity
+MATCH (a:Dog), (b:Dog) WHERE id(a) <> id(b)
+RETURN a.name AS a, b.name AS b,
+       a IN COLLECT { MATCH (d:Dog) WHERE id(d) = id(b) RETURN d } AS in_other,
+       a IN COLLECT { MATCH (d:Dog) WHERE id(d) = id(a) RETURN d } AS in_self
+ORDER BY a, b;
+-- a scalar is never a member of an element list
+RETURN 1 IN COLLECT { MATCH (d:Dog) RETURN d } AS r;
+-- error: a property cannot hold a list of nodes
+MATCH (p:Person) WITH p LIMIT 1 SET p.dogs = COLLECT { MATCH (d:Dog) RETURN d };
+
 -- error: the subquery must return exactly one column (Cypher form)
 RETURN COLLECT { MATCH (p:Person)-[:HAS_DOG]->(d:Dog) RETURN p.name, d.name };
 


### PR DESCRIPTION
Fixes AGV2-574

COLLECT { } and ARRAY { } gathered the body's column into a jsonb list whatever its type.  A node, relationship or path in that list came back as a picture of itself: an object of id, tid and properties.  Reading a property off a collected element found the object's top level and answered an empty value with no error, keys() listed id, tid and properties, label() refused the object, and SET stored the tid of a row into a property map.  The same body's column read through collect() or a list literal is the element itself.

A COLLECT or ARRAY whose column is a node, a relationship or a path now stays an array of that type, as collect() does.  The grammar wraps the ARRAY_SUBLINK as a Cypher expression instead of casting it, and the expression transform boxes its result to jsonb only when the element is not a graph element, through the same coercion as before, so every other COLLECT keeps its plan.  Membership of a graph element in the collected list is still a test by id, a scalar on the left of IN over a native element list is false instead of an error, and a property refuses the list the way it refuses collect().