### PR TITLE
fix: box a promoted property so a set operation or IN can match it

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -99,6 +99,9 @@ static Query *transformCypherStmt(ParseState *pstate, CypherStmt *stmt);
 static Query *transformCypherClause(ParseState *pstate, CypherClause *clause);
 
 static void preprocess_modifiers(CypherStmt *stmt);
+static bool isCypherSetOperation(Node *stmt);
+static Oid	boxCypherSetOpColumn(ParseState *pstate, Node *arg,
+								 TargetEntry *tle, int colno, bool recursive);
 static bool is_modifier(CypherClause *clause);
 static bool parent_is_projection(CypherClause *clause);
 static void attach_modifier(CypherClause *clause, CypherClause *modifier);
@@ -2073,6 +2076,105 @@ makeSortGroupClauseForSetOp(Oid rescoltype, bool require_hash)
 }
 
 /*
+ * isCypherSetOperation
+ *		Is every arm of this raw set operation a Cypher statement?  The Cypher
+ *		grammar wraps each arm as "SELECT * FROM (<cypher>) AS <alias>".
+ */
+static bool
+isCypherSetOperation(Node *stmt)
+{
+	SelectStmt *sel;
+	RangeSubselect *rs;
+
+	if (!IsA(stmt, SelectStmt))
+		return false;
+	sel = (SelectStmt *) stmt;
+
+	if (sel->op != SETOP_NONE)
+		return (isCypherSetOperation((Node *) sel->larg) &&
+				isCypherSetOperation((Node *) sel->rarg));
+
+	if (list_length(sel->fromClause) != 1 ||
+		!IsA(linitial(sel->fromClause), RangeSubselect))
+		return false;
+	rs = (RangeSubselect *) linitial(sel->fromClause);
+
+	return (IsA(rs->subquery, CypherStmt) &&
+			rs->alias != NULL &&
+			strcmp(rs->alias->aliasname, CYPHER_SUBQUERY_ALIAS) == 0);
+}
+
+/*
+ * boxCypherSetOpColumn
+ *		Box output column colno of a transformed set-operation arm to jsonb and
+ *		return its type.  tle is the entry the parent compares: a leaf's own
+ *		target entry, which is boxed in place, or the dummy standing for a
+ *		nested set operation, whose leaves are boxed and whose column type,
+ *		collation and grouping operator are brought in line.
+ */
+static Oid
+boxCypherSetOpColumn(ParseState *pstate, Node *arg, TargetEntry *tle,
+					 int colno, bool recursive)
+{
+	if (IsA(arg, RangeTblRef))
+	{
+		RangeTblEntry *rte = rt_fetch(((RangeTblRef *) arg)->rtindex,
+									  pstate->p_rtable);
+		ListCell   *lc;
+		int			n = 0;
+
+		foreach(lc, rte->subquery->targetList)
+		{
+			TargetEntry *leaftle = (TargetEntry *) lfirst(lc);
+
+			if (leaftle->resjunk)
+				continue;
+			if (n++ == colno)
+			{
+				Assert(tle == NULL || leaftle == tle);
+				leaftle->expr = (Expr *) coerceCypherValueToJsonb(pstate,
+													  (Node *) leaftle->expr);
+				return exprType((Node *) leaftle->expr);
+			}
+		}
+		elog(ERROR, "set-operation arm has no column %d", colno);
+	}
+	else
+	{
+		SetOperationStmt *op = castNode(SetOperationStmt, arg);
+		Oid			ltype;
+		Oid			rtype;
+		Oid			type;
+
+		ltype = boxCypherSetOpColumn(pstate, op->larg, NULL, colno, recursive);
+		rtype = boxCypherSetOpColumn(pstate, op->rarg, NULL, colno, recursive);
+		type = (ltype == rtype) ? ltype : InvalidOid;
+		if (!OidIsValid(type))
+			return InvalidOid;
+
+		lfirst_oid(list_nth_cell(op->colTypes, colno)) = type;
+		lfirst_int(list_nth_cell(op->colTypmods, colno)) = -1;
+		lfirst_oid(list_nth_cell(op->colCollations, colno)) = InvalidOid;
+		if (op->groupClauses != NIL)
+			lfirst(list_nth_cell(op->groupClauses, colno)) =
+				makeSortGroupClauseForSetOp(type, recursive);
+
+		if (tle != NULL)
+		{
+			SetToDefault *dummy = castNode(SetToDefault, tle->expr);
+
+			dummy->typeId = type;
+			dummy->typeMod = -1;
+			dummy->collation = InvalidOid;
+		}
+
+		return type;
+	}
+
+	return InvalidOid;			/* keep compiler quiet */
+}
+
+/*
  * transformSetOperationTree
  *		Recursively transform leaves and internal nodes of a set-op tree
  *
@@ -2224,6 +2326,7 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt,
 		const char *context;
 		bool		recursive = (pstate->p_parent_cte &&
 								 pstate->p_parent_cte->cterecursive);
+		bool		cypherSetOp = isCypherSetOperation((Node *) stmt);
 
 		context = (stmt->op == SETOP_UNION ? "UNION" :
 				   (stmt->op == SETOP_INTERSECT ? "INTERSECT" :
@@ -2286,6 +2389,29 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt,
 			Oid			rescoltype;
 			int32		rescoltypmod;
 			Oid			rescolcoll;
+
+			/*
+			 * A Cypher set operation combines Cypher values.  Two arm columns
+			 * with no common type are boxed to jsonb.
+			 */
+			if (cypherSetOp && lcoltype != rcoltype &&
+				!OidIsValid(select_common_type(pstate,
+											   list_make2(lcolnode, rcolnode),
+											   NULL, NULL)))
+			{
+				int			colno = foreach_current_index(ltl);
+
+				if (lcoltype != JSONBOID)
+					boxCypherSetOpColumn(pstate, op->larg, ltle, colno,
+										 recursive);
+				if (rcoltype != JSONBOID)
+					boxCypherSetOpColumn(pstate, op->rarg, rtle, colno,
+										 recursive);
+				lcolnode = (Node *) ltle->expr;
+				rcolnode = (Node *) rtle->expr;
+				lcoltype = exprType(lcolnode);
+				rcoltype = exprType(rcolnode);
+			}
 
 			/* select common type, same as CASE et al */
 			rescoltype = select_common_type(pstate,

--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -3331,6 +3331,20 @@ coerce_to_jsonb(ParseState *pstate, Node *expr, const char *targetname)
 	return coerce_all_to_jsonb(pstate, expr);
 }
 
+/*
+ * coerceCypherValueToJsonb
+ *		Box a Cypher value to jsonb.  A node, relationship or path is returned
+ *		as it is.
+ */
+Node *
+coerceCypherValueToJsonb(ParseState *pstate, Node *expr)
+{
+	if (is_graph_type(exprType(expr)))
+		return expr;
+
+	return coerce_all_to_jsonb(pstate, expr);
+}
+
 static bool
 is_graph_type(Oid type)
 {

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1841,6 +1841,7 @@ static Node *
 transformSubLink(ParseState *pstate, SubLink *sublink)
 {
 	Node	   *result = (Node *) sublink;
+	Node	   *subselect;
 	Query	   *qtree;
 	const char *err;
 
@@ -1946,6 +1947,8 @@ transformSubLink(ParseState *pstate, SubLink *sublink)
 
 	pstate->p_hasSubLinks = true;
 
+	subselect = sublink->subselect;
+
 	/*
 	 * OK, let's transform the sub-SELECT.
 	 */
@@ -1960,6 +1963,24 @@ transformSubLink(ParseState *pstate, SubLink *sublink)
 		elog(ERROR, "unexpected non-SELECT command in SubLink");
 
 	sublink->subselect = (Node *) qtree;
+
+	/*
+	 * "x IN { <cypher> }" compares x, cast to jsonb, with the body's column;
+	 * a column the body returned in its own type is boxed to jsonb here.
+	 */
+	if (sublink->subLinkType == ANY_SUBLINK && IsA(subselect, CypherStmt))
+	{
+		ListCell   *lc;
+
+		foreach(lc, qtree->targetList)
+		{
+			TargetEntry *tent = (TargetEntry *) lfirst(lc);
+
+			if (!tent->resjunk)
+				tent->expr = (Expr *) coerceCypherValueToJsonb(pstate,
+															   (Node *) tent->expr);
+		}
+	}
 
 	if (sublink->subLinkType == EXISTS_SUBLINK)
 	{

--- a/src/include/parser/parse_cypher_expr.h
+++ b/src/include/parser/parse_cypher_expr.h
@@ -42,6 +42,7 @@ extern List *transformCypherOrderBy(ParseState *pstate, List *orderlist,
 extern List *transformItemList(ParseState *pstate, List *items,
 							   ParseExprKind exprKind);
 extern void resolveItemList(ParseState *pstate, List *items);
+extern Node *coerceCypherValueToJsonb(ParseState *pstate, Node *expr);
 extern List *transformCypherExprList(ParseState *pstate, List *exprlist,
 									 ParseExprKind exprKind);
 

--- a/src/test/regress/expected/cypher_typed_column.out
+++ b/src/test/regress/expected/cypher_typed_column.out
@@ -3344,6 +3344,352 @@ MATCH ("a:b":doc) CALL { WITH "a:b" RETURN "a:b".age AS a } RETURN a ORDER BY a;
  60
 (6 rows)
 
+-- 11j. A set operation over a promoted arm and a plain arm.  The arms have no
+--      common type, so both are boxed to jsonb; the rows and the ordering
+--      match promotion off.  Arms that agree on a type, or that SQL unifies on
+--      its own, keep their native type.
+SET enable_property_promotion = on;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 20
+ 30
+ 40
+ 50
+ 60
+(5 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION ALL MATCH (p:plain) RETURN p.age AS v NEXT RETURN count(*) AS c;
+ c 
+---
+ 8
+(1 row)
+
+MATCH (n:doc) RETURN n.age AS v INTERSECT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 20
+ 40
+(2 rows)
+
+MATCH (n:doc) RETURN n.age AS v EXCEPT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 30
+ 50
+ 60
+(3 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.name AS v NEXT RETURN v ORDER BY v;
+  v   
+------
+ "n1"
+ "n2"
+ "n3"
+ "n4"
+ "n5"
+ "n6"
+ 20
+ 30
+ 40
+ 50
+ 60
+(11 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION RETURN 99 AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 20
+ 30
+ 40
+ 50
+ 60
+ 99
+(6 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (o:othertype) RETURN o.age AS v NEXT RETURN v ORDER BY v;
+    v    
+---------
+ "hello"
+ "world"
+ 20
+ 30
+ 40
+ 50
+ 60
+(7 rows)
+
+MATCH (n:doc) RETURN n.active AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+   v   
+-------
+ 20
+ 40
+ false
+ true
+ 
+(5 rows)
+
+MATCH ()-[r:rel]->() RETURN r.weight AS v UNION MATCH ()-[k:knows]->() RETURN k.weight AS v NEXT RETURN v ORDER BY v;
+ v 
+---
+ 7
+ 
+(2 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.big AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+  v  
+-----
+ 20
+ 30
+ 40
+ 50
+ 60
+ 100
+ 200
+ 300
+ 400
+ 
+(10 rows)
+
+MATCH (p:plain) CALL { MATCH (n:doc) RETURN n.age AS v UNION MATCH (q:plain) RETURN q.age AS v } RETURN p.name AS name, count(v) AS c ORDER BY name;
+ name | c 
+------+---
+ "p1" | 5
+ "p2" | 5
+(2 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.score AS v NEXT RETURN v ORDER BY v;
+  v   
+------
+ 1.00
+ 2.50
+ 3.50
+ 20
+ 30
+ 40
+ 50
+ 60
+ 
+(9 rows)
+
+MATCH (p:plain) WHERE p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+ name 
+------
+ "p1"
+ "p2"
+(2 rows)
+
+MATCH (p:plain) WHERE NOT p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+ name 
+------
+(0 rows)
+
+MATCH (n:doc) WHERE n.age IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+ name 
+------
+ "n1"
+ "n2"
+ "n5"
+(3 rows)
+
+MATCH (n:doc) WHERE n.active IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+ name 
+------
+(0 rows)
+
+SET enable_property_promotion = off;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 20
+ 30
+ 40
+ 50
+ 60
+(5 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION ALL MATCH (p:plain) RETURN p.age AS v NEXT RETURN count(*) AS c;
+ c 
+---
+ 8
+(1 row)
+
+MATCH (n:doc) RETURN n.age AS v INTERSECT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 20
+ 40
+(2 rows)
+
+MATCH (n:doc) RETURN n.age AS v EXCEPT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 30
+ 50
+ 60
+(3 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.name AS v NEXT RETURN v ORDER BY v;
+  v   
+------
+ "n1"
+ "n2"
+ "n3"
+ "n4"
+ "n5"
+ "n6"
+ 20
+ 30
+ 40
+ 50
+ 60
+(11 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION RETURN 99 AS v NEXT RETURN v ORDER BY v;
+ v  
+----
+ 20
+ 30
+ 40
+ 50
+ 60
+ 99
+(6 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (o:othertype) RETURN o.age AS v NEXT RETURN v ORDER BY v;
+    v    
+---------
+ "hello"
+ "world"
+ 20
+ 30
+ 40
+ 50
+ 60
+(7 rows)
+
+MATCH (n:doc) RETURN n.active AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+   v   
+-------
+ 20
+ 40
+ false
+ true
+ 
+(5 rows)
+
+MATCH ()-[r:rel]->() RETURN r.weight AS v UNION MATCH ()-[k:knows]->() RETURN k.weight AS v NEXT RETURN v ORDER BY v;
+ v 
+---
+ 7
+ 
+(2 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.big AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+  v  
+-----
+ 20
+ 30
+ 40
+ 50
+ 60
+ 100
+ 200
+ 300
+ 400
+ 
+(10 rows)
+
+MATCH (p:plain) CALL { MATCH (n:doc) RETURN n.age AS v UNION MATCH (q:plain) RETURN q.age AS v } RETURN p.name AS name, count(v) AS c ORDER BY name;
+ name | c 
+------+---
+ "p1" | 5
+ "p2" | 5
+(2 rows)
+
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.score AS v NEXT RETURN v ORDER BY v;
+  v   
+------
+ 1.00
+ 2.50
+ 3.50
+ 20
+ 30
+ 40
+ 50
+ 60
+ 
+(9 rows)
+
+MATCH (p:plain) WHERE p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+ name 
+------
+ "p1"
+ "p2"
+(2 rows)
+
+MATCH (p:plain) WHERE NOT p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+ name 
+------
+(0 rows)
+
+MATCH (n:doc) WHERE n.age IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+ name 
+------
+ "n1"
+ "n2"
+ "n5"
+(3 rows)
+
+MATCH (n:doc) WHERE n.active IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+ name 
+------
+(0 rows)
+
+-- the result type: jsonb where the arms had no common type, the arms' own type
+-- where they agree or where SQL unifies them, and the box lands on the
+-- promoted arm only
+SET enable_property_promotion = on;
+SELECT pg_typeof(v) AS mixed FROM (MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v) q LIMIT 1;
+ mixed 
+-------
+ jsonb
+(1 row)
+
+SELECT pg_typeof(v) AS same FROM (MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.age AS v) q LIMIT 1;
+  same   
+---------
+ integer
+(1 row)
+
+SELECT pg_typeof(v) AS unified FROM (MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.big AS v) q LIMIT 1;
+ unified 
+---------
+ bigint
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v;
+                  QUERY PLAN                  
+----------------------------------------------
+ HashAggregate
+   Output: (cypher_to_jsonb(n.age))
+   Group Key: (cypher_to_jsonb(n.age))
+   ->  Append
+         ->  Seq Scan on tc.doc n
+               Output: cypher_to_jsonb(n.age)
+         ->  Seq Scan on tc.plain p
+               Output: p.properties.'age'
+(8 rows)
+
+-- a boolean arm against a jsonb arm follows the same rule
+RETURN true AS v UNION RETURN 'x' AS v NEXT RETURN v ORDER BY v;
+  v   
+------
+ "x"
+ true
+(2 rows)
+
 -- ============================================================================
 -- SECTION 12 -- NULL / missing-key semantics (on == off)
 --

--- a/src/test/regress/sql/cypher_typed_column.sql
+++ b/src/test/regress/sql/cypher_typed_column.sql
@@ -1201,6 +1201,56 @@ SET enable_property_promotion = off;
 MATCH ("a:b":doc) WHERE "a:b".name = 'n1' RETURN "a:b".age AS a;
 MATCH ("a:b":doc) CALL { WITH "a:b" RETURN "a:b".age AS a } RETURN a ORDER BY a;
 
+-- 11j. A set operation over a promoted arm and a plain arm.  The arms have no
+--      common type, so both are boxed to jsonb; the rows and the ordering
+--      match promotion off.  Arms that agree on a type, or that SQL unifies on
+--      its own, keep their native type.
+SET enable_property_promotion = on;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION ALL MATCH (p:plain) RETURN p.age AS v NEXT RETURN count(*) AS c;
+MATCH (n:doc) RETURN n.age AS v INTERSECT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v EXCEPT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.name AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION RETURN 99 AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (o:othertype) RETURN o.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.active AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH ()-[r:rel]->() RETURN r.weight AS v UNION MATCH ()-[k:knows]->() RETURN k.weight AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.big AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (p:plain) CALL { MATCH (n:doc) RETURN n.age AS v UNION MATCH (q:plain) RETURN q.age AS v } RETURN p.name AS name, count(v) AS c ORDER BY name;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.score AS v NEXT RETURN v ORDER BY v;
+MATCH (p:plain) WHERE p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+MATCH (p:plain) WHERE NOT p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+MATCH (n:doc) WHERE n.age IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+MATCH (n:doc) WHERE n.active IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+SET enable_property_promotion = off;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION ALL MATCH (p:plain) RETURN p.age AS v NEXT RETURN count(*) AS c;
+MATCH (n:doc) RETURN n.age AS v INTERSECT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v EXCEPT MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.name AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION RETURN 99 AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (o:othertype) RETURN o.age AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.active AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH ()-[r:rel]->() RETURN r.weight AS v UNION MATCH ()-[k:knows]->() RETURN k.weight AS v NEXT RETURN v ORDER BY v;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.big AS v UNION MATCH (p:plain) RETURN p.age AS v NEXT RETURN v ORDER BY v;
+MATCH (p:plain) CALL { MATCH (n:doc) RETURN n.age AS v UNION MATCH (q:plain) RETURN q.age AS v } RETURN p.name AS name, count(v) AS c ORDER BY name;
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.score AS v NEXT RETURN v ORDER BY v;
+MATCH (p:plain) WHERE p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+MATCH (p:plain) WHERE NOT p.age IN { MATCH (n:doc) RETURN n.age } RETURN p.name AS name ORDER BY name;
+MATCH (n:doc) WHERE n.age IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+MATCH (n:doc) WHERE n.active IN { MATCH (p:plain) RETURN p.age } RETURN n.name AS name ORDER BY name;
+-- the result type: jsonb where the arms had no common type, the arms' own type
+-- where they agree or where SQL unifies them, and the box lands on the
+-- promoted arm only
+SET enable_property_promotion = on;
+SELECT pg_typeof(v) AS mixed FROM (MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v) q LIMIT 1;
+SELECT pg_typeof(v) AS same FROM (MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.age AS v) q LIMIT 1;
+SELECT pg_typeof(v) AS unified FROM (MATCH (n:doc) RETURN n.age AS v UNION MATCH (n:doc) RETURN n.big AS v) q LIMIT 1;
+EXPLAIN (VERBOSE, COSTS OFF)
+MATCH (n:doc) RETURN n.age AS v UNION MATCH (p:plain) RETURN p.age AS v;
+-- a boolean arm against a jsonb arm follows the same rule
+RETURN true AS v UNION RETURN 'x' AS v NEXT RETURN v ORDER BY v;
+
 -- ============================================================================
 -- SECTION 12 -- NULL / missing-key semantics (on == off)
 --


### PR DESCRIPTION
A promoted property read comes back in the column's own type, as the manual says.  Inside one query that is fine: every clause and expression takes the native value.  A set operation is the exception.  It unifies its arms' columns by SQL's rules, and text has no common type with jsonb, so MATCH (n:prom) RETURN n.nm UNION MATCH (n:bare) RETURN n.nm failed with "UNION types text and jsonb cannot be matched".  So did INTERSECT and EXCEPT, a promoted key against a plain key of the same label, a promoted arm against a literal, promoted edge labels, and the same union inside CALL { } or as a NEXT operand.  x IN { MATCH (n:prom) RETURN n.nm } failed with "operator does not exist: jsonb = text" for the same reason: the left side is cast to jsonb because a Cypher RETURN column is jsonb, and here it was not.  RETURN true UNION RETURN 'x' failed the same way before promotion existed.

A Cypher set operation now boxes an arm column to jsonb when the arms have no common type.  A leaf arm is boxed in the wrapper the grammar puts around it, so its own WHERE and ORDER BY keep the typed column and its index; a nested set operation has its leaves boxed and its column type, collation and grouping operator brought in line.  Arms that agree, or that SQL unifies on its own such as int with bigint, are untouched and keep their native type and plan.  A node, relationship or path is not boxed.  The body of x IN { } is boxed the same way.

The mixed result is jsonb, as with promotion off.  On 200,000 rows per arm a mixed UNION takes 456 ms against 379 ms with promotion off, the cost of the conversion itself; a union of two promoted arms of one type stays native at 235 ms against 349 ms boxed.