### PR TITLE
fix: yield only what the called function returns

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -20,6 +20,7 @@
 #include "catalog/ag_label.h"
 #include "catalog/ag_label_fn.h"
 #include "catalog/ag_vertex_d.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_class.h"
@@ -382,6 +383,8 @@ static bool nsItemHasColumnNamed(ParseNamespaceItem *nsitem,
 static List *joinCallBody(ParseState *pstate,
 						  ParseNamespaceItem *prev_nsitem,
 						  ParseNamespaceItem *body_nsitem, bool optional);
+static List *selectYieldItems(ParseState *pstate, Query *subqry,
+							  CypherYieldCallClause *detail);
 
 /* graph write */
 static List *addRangeTableAllModifiedLabels(ParseState *pstate, Query *qry,
@@ -2242,8 +2245,8 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
  *		is analyzed as a function scan and joined in as a subquery RTE, exactly
  *		like the FOR clause's unnest.  It is LATERAL when a previous clause
  *		exists, so the arguments may reference the outer variables; the YIELD
- *		list projects (and optionally renames) the routine's output columns,
- *		which then surface to the clauses that follow.
+ *		list selects (and optionally renames) among the routine's output
+ *		columns, which then surface to the clauses that follow.
  *
  *		OPTIONAL CALL keeps an input row for which the routine yields no rows,
  *		binding the yielded columns to null for it; see joinCallBody().
@@ -2300,9 +2303,11 @@ transformCypherYieldCallClause(ParseState *pstate, CypherClause *clause)
 	rf->alias = NULL;
 	rf->coldeflist = NIL;
 
-	/* SELECT <yield items> FROM func(args) */
+	/* SELECT * FROM func(args) */
 	subquery = makeNode(SelectStmt);
-	subquery->targetList = detail->yielditems;
+	subquery->targetList =
+		list_make1(makeResTarget(makeColumnRef(list_make1(makeNode(A_Star))),
+								 NULL));
 	subquery->fromClause = list_make1(rf);
 
 	/*
@@ -2318,6 +2323,8 @@ transformCypherYieldCallClause(ParseState *pstate, CypherClause *clause)
 
 	pstate->p_lateral_active = false;
 	pstate->p_expr_kind = EXPR_KIND_NONE;
+
+	subqry->targetList = selectYieldItems(pstate, subqry, detail);
 
 	nsitem = addRangeTableEntryForSubquery(pstate, subqry,
 										   makeAliasNoDup(CYPHER_YIELD_ALIAS, NIL),
@@ -2369,6 +2376,66 @@ transformCypherYieldCallClause(ParseState *pstate, CypherClause *clause)
 	assign_query_collations(pstate, qry);
 
 	return qry;
+}
+
+/*
+ * selectYieldItems
+ *		Select and rename what a YIELD list names from the routine's result.
+ *
+ *		subqry is the analyzed SELECT * over the routine, its target list one
+ *		entry per output column.  A yield item is an output column, or the
+ *		routine's own name for its whole row, and nothing else: a variable of
+ *		the enclosing query is never a candidate.  YIELD * keeps the target
+ *		list as it is.
+ */
+static List *
+selectYieldItems(ParseState *pstate, Query *subqry, CypherYieldCallClause *detail)
+{
+	RangeTblEntry *rte = rt_fetch(1, subqry->rtable);
+	ColumnRef  *first;
+	List	   *result = NIL;
+	ListCell   *lc;
+
+	Assert(rte->rtekind == RTE_FUNCTION);
+
+	first = castNode(ColumnRef, linitial_node(ResTarget, detail->yielditems)->val);
+	if (IsA(linitial(first->fields), A_Star))
+		return subqry->targetList;
+
+	foreach(lc, detail->yielditems)
+	{
+		ResTarget  *rt = lfirst_node(ResTarget, lc);
+		ColumnRef  *cref = castNode(ColumnRef, rt->val);
+		char	   *colname = strVal(linitial(cref->fields));
+		Expr	   *expr = NULL;
+		ListCell   *lc2;
+
+		foreach(lc2, subqry->targetList)
+		{
+			TargetEntry *te = lfirst_node(TargetEntry, lc2);
+
+			if (strcmp(te->resname, colname) == 0)
+			{
+				expr = copyObject(te->expr);
+				break;
+			}
+		}
+		if (expr == NULL && strcmp(colname, rte->eref->aliasname) == 0)
+			expr = (Expr *) makeWholeRowVar(rte, 1, 0, true);
+		if (expr == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_COLUMN),
+					 errmsg("function %s has no output column \"%s\"",
+							NameListToString(detail->funcname), colname),
+					 parser_errposition(pstate, cref->location)));
+
+		result = lappend(result,
+						 makeTargetEntry(expr, list_length(result) + 1,
+										 rt->name != NULL ? rt->name : colname,
+										 false));
+	}
+
+	return result;
 }
 
 /*

--- a/src/test/regress/expected/cypher_yield.out
+++ b/src/test/regress/expected/cypher_yield.out
@@ -50,7 +50,9 @@
 -- matrix of a nulled column, null semantics downstream, composition with the
 -- surrounding pipeline and with the inline call form, plan shapes, the errors and
 -- placement guards it does not relax -- followed by backward compatibility of
--- "yield" as an ordinary identifier plus keyword case-folding.
+-- "yield" as an ordinary identifier plus keyword case-folding, the built-in
+-- set-returning functions as routines, and the rule that a yield item names an
+-- output column of the routine and nothing else.
 --
 -- Set up
 CREATE GRAPH cypher_yield;
@@ -91,6 +93,9 @@ $$ SELECT 1 WHERE (age #>> '{}')::int >= 30 $$;
 -- A routine whose single parameter is a plain int, used only to demonstrate the
 -- jsonb-property/int-parameter typing boundary.
 CREATE FUNCTION yc_int(n int) RETURNS TABLE(x int) LANGUAGE sql AS $$ SELECT n $$;
+-- A routine returning whole vertices, yielded as a row under the routine's name.
+CREATE FUNCTION yc_people() RETURNS SETOF vertex LANGUAGE sql STABLE AS
+$$ MATCH (p:person) RETURN p ORDER BY p.id $$;
 --
 -- 1. Multi-column TABLE routine -- every YIELD form
 --
@@ -1163,6 +1168,111 @@ SELECT value FROM jsonb_array_elements('[10, 20, 30]'::jsonb) AS value ORDER BY 
  30
 (3 rows)
 
+--
+-- 15. A yield item names an output column of the routine and nothing else
+--
+-- The variables the preceding clauses bound are not candidates: a yield item
+-- that is not an output column of the routine is an error, however the name is
+-- bound outside the call.
+-- The vertex bound by the preceding MATCH
+MATCH (p:person {id: 1}) CALL yc_table() YIELD p AS m
+RETURN m;
+ERROR:  function yc_table has no output column "p"
+LINE 1: MATCH (p:person {id: 1}) CALL yc_table() YIELD p AS m
+                                                       ^
+-- A scalar introduced by WITH, an UNWIND item, a LET binding
+MATCH (p:person {id: 1}) WITH p.age AS age CALL yc_table() YIELD age AS x
+RETURN x;
+ERROR:  function yc_table has no output column "age"
+LINE 1: ...on {id: 1}) WITH p.age AS age CALL yc_table() YIELD age AS x
+                                                               ^
+UNWIND [1, 2] AS u CALL yc_table() YIELD u
+RETURN u;
+ERROR:  function yc_table has no output column "u"
+LINE 1: UNWIND [1, 2] AS u CALL yc_table() YIELD u
+                                                 ^
+MATCH (p:person {id: 1}) LET age = p.age CALL yc_table() YIELD age
+RETURN age;
+ERROR:  function yc_table has no output column "age"
+LINE 1: ...(p:person {id: 1}) LET age = p.age CALL yc_table() YIELD age
+                                                                    ^
+-- A name bound nowhere
+MATCH (p:person {id: 1}) CALL yc_table() YIELD nosuch
+RETURN nosuch;
+ERROR:  function yc_table has no output column "nosuch"
+LINE 1: MATCH (p:person {id: 1}) CALL yc_table() YIELD nosuch
+                                                       ^
+-- The routine's own name is its whole row: a vertex for a routine returning
+-- vertices, a record for a multi-column one.  An output column of that name
+-- would come first (section 2: generate_series).
+MATCH (p:person {id: 1}) CALL yc_people() YIELD yc_people AS v
+RETURN v.name AS nm, v.age = p.age AS same_age ORDER BY nm;
+   nm    | same_age 
+---------+----------
+ "alice" | t
+ "bob"   | f
+ "carol" | f
+ "dave"  | f
+(4 rows)
+
+MATCH (p:person {id: 1}) CALL yc_table() YIELD yc_table AS row
+RETURN row ORDER BY row;
+          row           
+------------------------
+ {"a": 1, "b": "one"}
+ {"a": 2, "b": "two"}
+ {"a": 3, "b": "three"}
+(3 rows)
+
+-- ... and an outer variable of the routine's name does not take its place.
+MATCH (yc_people:person {id: 1}) CALL yc_people() YIELD yc_people AS v
+RETURN v.name AS nm ORDER BY nm;
+   nm    
+---------
+ "alice"
+ "bob"
+ "carol"
+ "dave"
+(4 rows)
+
+-- The error names the routine as it was written
+MATCH (p:person {id: 1}) CALL pg_catalog.generate_series(1, 2) YIELD p AS m
+RETURN m;
+ERROR:  function pg_catalog.generate_series has no output column "p"
+LINE 1: ... {id: 1}) CALL pg_catalog.generate_series(1, 2) YIELD p AS m
+                                                                 ^
+-- OPTIONAL CALL resolves the yield list the same way
+MATCH (p:person {id: 1}) OPTIONAL CALL yc_table() YIELD p AS m
+RETURN m;
+ERROR:  function yc_table has no output column "p"
+LINE 1: ...TCH (p:person {id: 1}) OPTIONAL CALL yc_table() YIELD p AS m
+                                                                 ^
+-- So does a yield item that is then written to
+MATCH (p:person {id: 1}) CALL yc_table() YIELD p AS m
+SET m.flag = 1;
+ERROR:  function yc_table has no output column "p"
+LINE 1: MATCH (p:person {id: 1}) CALL yc_table() YIELD p AS m
+                                                       ^
+-- The same output column may be yielded twice under two names, and the yield
+-- list sets the column order.
+MATCH (p:person {id: 1}) CALL yc_table() YIELD a AS x, a AS y
+RETURN x, y ORDER BY x;
+ x | y 
+---+---
+ 1 | 1
+ 2 | 2
+ 3 | 3
+(3 rows)
+
+MATCH (p:person {id: 1}) CALL yc_table() YIELD b, a
+RETURN b, a ORDER BY a;
+    b    | a 
+---------+---
+ "one"   | 1
+ "two"   | 2
+ "three" | 3
+(3 rows)
+
 -- Tear down
 DROP FUNCTION yc_table();
 DROP FUNCTION yc_dup(jsonb, int);
@@ -1171,6 +1281,7 @@ DROP FUNCTION yc_zero();
 DROP FUNCTION yc_ids();
 DROP FUNCTION yc_ge30(jsonb);
 DROP FUNCTION yc_int(int);
+DROP FUNCTION yc_people();
 DROP GRAPH cypher_yield CASCADE;
 NOTICE:  drop cascades to 6 other objects
 DETAIL:  drop cascades to sequence cypher_yield.ag_label_seq

--- a/src/test/regress/sql/cypher_yield.sql
+++ b/src/test/regress/sql/cypher_yield.sql
@@ -50,7 +50,9 @@
 -- matrix of a nulled column, null semantics downstream, composition with the
 -- surrounding pipeline and with the inline call form, plan shapes, the errors and
 -- placement guards it does not relax -- followed by backward compatibility of
--- "yield" as an ordinary identifier plus keyword case-folding.
+-- "yield" as an ordinary identifier plus keyword case-folding, the built-in
+-- set-returning functions as routines, and the rule that a yield item names an
+-- output column of the routine and nothing else.
 --
 
 -- Set up
@@ -101,6 +103,10 @@ $$ SELECT 1 WHERE (age #>> '{}')::int >= 30 $$;
 -- A routine whose single parameter is a plain int, used only to demonstrate the
 -- jsonb-property/int-parameter typing boundary.
 CREATE FUNCTION yc_int(n int) RETURNS TABLE(x int) LANGUAGE sql AS $$ SELECT n $$;
+
+-- A routine returning whole vertices, yielded as a row under the routine's name.
+CREATE FUNCTION yc_people() RETURNS SETOF vertex LANGUAGE sql STABLE AS
+$$ MATCH (p:person) RETURN p ORDER BY p.id $$;
 
 --
 -- 1. Multi-column TABLE routine -- every YIELD form
@@ -588,6 +594,52 @@ MATCH (p:person {id: 1}) UNWIND [10, 20, 30] AS v
 RETURN v ORDER BY v;
 SELECT value FROM jsonb_array_elements('[10, 20, 30]'::jsonb) AS value ORDER BY value;
 
+--
+-- 15. A yield item names an output column of the routine and nothing else
+--
+-- The variables the preceding clauses bound are not candidates: a yield item
+-- that is not an output column of the routine is an error, however the name is
+-- bound outside the call.
+
+-- The vertex bound by the preceding MATCH
+MATCH (p:person {id: 1}) CALL yc_table() YIELD p AS m
+RETURN m;
+-- A scalar introduced by WITH, an UNWIND item, a LET binding
+MATCH (p:person {id: 1}) WITH p.age AS age CALL yc_table() YIELD age AS x
+RETURN x;
+UNWIND [1, 2] AS u CALL yc_table() YIELD u
+RETURN u;
+MATCH (p:person {id: 1}) LET age = p.age CALL yc_table() YIELD age
+RETURN age;
+-- A name bound nowhere
+MATCH (p:person {id: 1}) CALL yc_table() YIELD nosuch
+RETURN nosuch;
+-- The routine's own name is its whole row: a vertex for a routine returning
+-- vertices, a record for a multi-column one.  An output column of that name
+-- would come first (section 2: generate_series).
+MATCH (p:person {id: 1}) CALL yc_people() YIELD yc_people AS v
+RETURN v.name AS nm, v.age = p.age AS same_age ORDER BY nm;
+MATCH (p:person {id: 1}) CALL yc_table() YIELD yc_table AS row
+RETURN row ORDER BY row;
+-- ... and an outer variable of the routine's name does not take its place.
+MATCH (yc_people:person {id: 1}) CALL yc_people() YIELD yc_people AS v
+RETURN v.name AS nm ORDER BY nm;
+-- The error names the routine as it was written
+MATCH (p:person {id: 1}) CALL pg_catalog.generate_series(1, 2) YIELD p AS m
+RETURN m;
+-- OPTIONAL CALL resolves the yield list the same way
+MATCH (p:person {id: 1}) OPTIONAL CALL yc_table() YIELD p AS m
+RETURN m;
+-- So does a yield item that is then written to
+MATCH (p:person {id: 1}) CALL yc_table() YIELD p AS m
+SET m.flag = 1;
+-- The same output column may be yielded twice under two names, and the yield
+-- list sets the column order.
+MATCH (p:person {id: 1}) CALL yc_table() YIELD a AS x, a AS y
+RETURN x, y ORDER BY x;
+MATCH (p:person {id: 1}) CALL yc_table() YIELD b, a
+RETURN b, a ORDER BY a;
+
 -- Tear down
 DROP FUNCTION yc_table();
 DROP FUNCTION yc_dup(jsonb, int);
@@ -596,4 +648,5 @@ DROP FUNCTION yc_zero();
 DROP FUNCTION yc_ids();
 DROP FUNCTION yc_ge30(jsonb);
 DROP FUNCTION yc_int(int);
+DROP FUNCTION yc_people();
 DROP GRAPH cypher_yield CASCADE;


### PR DESCRIPTION
CALL func(args) YIELD items was analyzed as SELECT items FROM func(args), a lateral subquery whose select list resolves names like any SQL expression: a name the function does not return fell through to the enclosing query, so MATCH (p:Person) CALL generate_series(1, 2) YIELD p AS m silently bound m to the outer vertex, and likewise for an edge, a path, a WITH, LET, UNWIND, FOR or CALL variable.  A yield item names a column of the function's result and nothing else (GQL 16.14), so the subquery is now SELECT * over the function and the yield list selects and renames among its columns; the function's own name still yields its whole row, as SQL lets a table alias stand for its row, which is how a function returning vertices or edges is yielded.  Any other name is refused with "function f has no output column".  YIELD * and the plans of every accepted query are unchanged.