### PR TITLE
fix: match a graph element in a subquery by identity

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -99,9 +99,9 @@ static Query *transformCypherStmt(ParseState *pstate, CypherStmt *stmt);
 static Query *transformCypherClause(ParseState *pstate, CypherClause *clause);
 
 static void preprocess_modifiers(CypherStmt *stmt);
-static bool isCypherSetOperation(Node *stmt);
-static Oid	boxCypherSetOpColumn(ParseState *pstate, Node *arg,
-								 TargetEntry *tle, int colno, bool recursive);
+static Oid	rewriteSetOpColumn(ParseState *pstate, List *rtable, Node *arg,
+							   TargetEntry *tle, int colno, bool require_hash,
+							   CypherColumnRewrite rewrite);
 static bool is_modifier(CypherClause *clause);
 static bool projection_takes_modifiers(CypherClause *clause);
 static bool parent_is_projection(CypherClause *clause);
@@ -2081,7 +2081,7 @@ makeSortGroupClauseForSetOp(Oid rescoltype, bool require_hash)
  *		Is every arm of this raw set operation a Cypher statement?  The Cypher
  *		grammar wraps each arm as "SELECT * FROM (<cypher>) AS <alias>".
  */
-static bool
+bool
 isCypherSetOperation(Node *stmt)
 {
 	SelectStmt *sel;
@@ -2106,21 +2106,21 @@ isCypherSetOperation(Node *stmt)
 }
 
 /*
- * boxCypherSetOpColumn
- *		Box output column colno of a transformed set-operation arm to jsonb and
+ * rewriteSetOpColumn
+ *		Rewrite output column colno of a transformed set-operation arm and
  *		return its type.  tle is the entry the parent compares: a leaf's own
- *		target entry, which is boxed in place, or the dummy standing for a
- *		nested set operation, whose leaves are boxed and whose column type,
+ *		target entry, which is rewritten in place, or the dummy standing for a
+ *		nested set operation, whose leaves are rewritten and whose column type,
  *		collation and grouping operator are brought in line.
  */
 static Oid
-boxCypherSetOpColumn(ParseState *pstate, Node *arg, TargetEntry *tle,
-					 int colno, bool recursive)
+rewriteSetOpColumn(ParseState *pstate, List *rtable, Node *arg,
+				   TargetEntry *tle, int colno, bool require_hash,
+				   CypherColumnRewrite rewrite)
 {
 	if (IsA(arg, RangeTblRef))
 	{
-		RangeTblEntry *rte = rt_fetch(((RangeTblRef *) arg)->rtindex,
-									  pstate->p_rtable);
+		RangeTblEntry *rte = rt_fetch(((RangeTblRef *) arg)->rtindex, rtable);
 		ListCell   *lc;
 		int			n = 0;
 
@@ -2133,8 +2133,7 @@ boxCypherSetOpColumn(ParseState *pstate, Node *arg, TargetEntry *tle,
 			if (n++ == colno)
 			{
 				Assert(tle == NULL || leaftle == tle);
-				leaftle->expr = (Expr *) coerceCypherValueToJsonb(pstate,
-													  (Node *) leaftle->expr);
+				leaftle->expr = (Expr *) rewrite(pstate, (Node *) leaftle->expr);
 				return exprType((Node *) leaftle->expr);
 			}
 		}
@@ -2147,8 +2146,10 @@ boxCypherSetOpColumn(ParseState *pstate, Node *arg, TargetEntry *tle,
 		Oid			rtype;
 		Oid			type;
 
-		ltype = boxCypherSetOpColumn(pstate, op->larg, NULL, colno, recursive);
-		rtype = boxCypherSetOpColumn(pstate, op->rarg, NULL, colno, recursive);
+		ltype = rewriteSetOpColumn(pstate, rtable, op->larg, NULL, colno,
+								   require_hash, rewrite);
+		rtype = rewriteSetOpColumn(pstate, rtable, op->rarg, NULL, colno,
+								   require_hash, rewrite);
 		type = (ltype == rtype) ? ltype : InvalidOid;
 		if (!OidIsValid(type))
 			return InvalidOid;
@@ -2158,7 +2159,7 @@ boxCypherSetOpColumn(ParseState *pstate, Node *arg, TargetEntry *tle,
 		lfirst_oid(list_nth_cell(op->colCollations, colno)) = InvalidOid;
 		if (op->groupClauses != NIL)
 			lfirst(list_nth_cell(op->groupClauses, colno)) =
-				makeSortGroupClauseForSetOp(type, recursive);
+				makeSortGroupClauseForSetOp(type, require_hash);
 
 		if (tle != NULL)
 		{
@@ -2173,6 +2174,43 @@ boxCypherSetOpColumn(ParseState *pstate, Node *arg, TargetEntry *tle,
 	}
 
 	return InvalidOid;			/* keep compiler quiet */
+}
+
+/*
+ * rewriteCypherSetOpColumn
+ *		Rewrite output column colno of an analyzed set-operation query in every
+ *		leaf, and give the query's own target entry the rewritten type.
+ */
+void
+rewriteCypherSetOpColumn(ParseState *pstate, Query *qry, int colno,
+						 CypherColumnRewrite rewrite)
+{
+	Oid			type;
+	ListCell   *lc;
+	int			n = 0;
+
+	type = rewriteSetOpColumn(pstate, qry->rtable, qry->setOperations, NULL,
+							  colno, false, rewrite);
+	if (!OidIsValid(type))
+		elog(ERROR, "set-operation arms disagree on the type of column %d",
+			 colno);
+
+	foreach(lc, qry->targetList)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+
+		if (tle->resjunk)
+			continue;
+		if (n++ == colno)
+		{
+			Var		   *var = castNode(Var, tle->expr);
+
+			var->vartype = type;
+			var->vartypmod = -1;
+			var->varcollid = InvalidOid;
+			break;
+		}
+	}
 }
 
 /*
@@ -2403,11 +2441,11 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt,
 				int			colno = foreach_current_index(ltl);
 
 				if (lcoltype != JSONBOID)
-					boxCypherSetOpColumn(pstate, op->larg, ltle, colno,
-										 recursive);
+					rewriteSetOpColumn(pstate, pstate->p_rtable, op->larg, ltle,
+									   colno, recursive, coerceCypherValueToJsonb);
 				if (rcoltype != JSONBOID)
-					boxCypherSetOpColumn(pstate, op->rarg, rtle, colno,
-										 recursive);
+					rewriteSetOpColumn(pstate, pstate->p_rtable, op->rarg, rtle,
+									   colno, recursive, coerceCypherValueToJsonb);
 				lcolnode = (Node *) ltle->expr;
 				rcolnode = (Node *) rtle->expr;
 				lcoltype = exprType(lcolnode);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -20113,12 +20113,13 @@ cypher_expr:
 					 * "x IN { <cypher read subquery> }".  Built as a native
 					 * ANY_SUBLINK so the planner can pull it up to a semi-join
 					 * or run it as a hashed subplan, rather than materializing
-					 * the whole result set.  A cypher RETURN column is jsonb,
-					 * so the left operand is cast to jsonb for the comparison.
+					 * the whole result set.  How x is compared with the
+					 * subquery's column is settled once both types are known,
+					 * in transformCypherInSubquery().
 					 */
 					n->subLinkType = ANY_SUBLINK;
 					n->subLinkId = 0;
-					n->testexpr = makeTypeCast($1, SystemTypeName("jsonb"), @1);
+					n->testexpr = $1;
 					n->operName = NIL;
 					n->subselect = $4;
 					n->location = @2;
@@ -20130,7 +20131,7 @@ cypher_expr:
 
 					n->subLinkType = ANY_SUBLINK;
 					n->subLinkId = 0;
-					n->testexpr = makeTypeCast($1, SystemTypeName("jsonb"), @1);
+					n->testexpr = $1;
 					n->operName = NIL;
 					n->subselect = $5;
 					n->location = @2;
@@ -20734,7 +20735,7 @@ cypher_w_expr:
 
 					n->subLinkType = ANY_SUBLINK;
 					n->subLinkId = 0;
-					n->testexpr = makeTypeCast($1, SystemTypeName("jsonb"), @1);
+					n->testexpr = $1;
 					n->operName = NIL;
 					n->subselect = $4;
 					n->location = @2;
@@ -20746,7 +20747,7 @@ cypher_w_expr:
 
 					n->subLinkType = ANY_SUBLINK;
 					n->subLinkId = 0;
-					n->testexpr = makeTypeCast($1, SystemTypeName("jsonb"), @1);
+					n->testexpr = $1;
 					n->operName = NIL;
 					n->subselect = $5;
 					n->location = @2;

--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -109,6 +109,8 @@ static Node *coerce_to_jsonb(ParseState *pstate, Node *expr,
 							 const char *targetname);
 static bool is_graph_type(Oid type);
 static Node *coerce_all_to_jsonb(ParseState *pstate, Node *expr);
+static Node *reduce_in_operand_to_id(ParseState *pstate, Node *expr);
+static Node *coerce_in_operand_to_jsonb(ParseState *pstate, Node *expr);
 
 static List *transformA_Star(ParseState *pstate, int location);
 static Node *build_cypher_cast_expr(Node *expr, Oid otyp, int32 otypmod,
@@ -2695,6 +2697,83 @@ reduce_graph_elem_to_id(ParseState *pstate, Node *elem, int location)
 						format_type_be(typoid)),
 				 parser_errposition(pstate, location)));
 	return id;
+}
+
+/*
+ * transformCypherInSubquery
+ *		Transform the left operand of "x IN { <cypher> }" and match it to the
+ *		column of the analyzed subquery qtree, the way "x IN [list]" matches its
+ *		operands: a node, relationship or graphid on both sides is compared by
+ *		identity, one on the left only is a type error, and any other value is
+ *		compared as jsonb.
+ */
+Node *
+transformCypherInSubquery(ParseState *pstate, Node *testexpr, Query *qtree)
+{
+	Node	   *lhs;
+	TargetEntry *tle = NULL;
+	CypherColumnRewrite rewrite;
+	ListCell   *lc;
+
+	if (IsA(testexpr, CypherGenericExpr))
+		testexpr = ((CypherGenericExpr *) testexpr)->expr;
+	lhs = transformCypherExprRecurse(pstate, testexpr);
+
+	/* transformSubLink() reports a column count other than one */
+	foreach(lc, qtree->targetList)
+	{
+		TargetEntry *te = lfirst_node(TargetEntry, lc);
+
+		if (te->resjunk)
+			continue;
+		if (tle != NULL)
+			return lhs;
+		tle = te;
+	}
+	if (tle == NULL)
+		return lhs;
+
+	if (is_id_reducible_graph_type(exprType(lhs)))
+	{
+		lhs = reduce_graph_elem_to_id(pstate, lhs, exprLocation(lhs));
+		rewrite = reduce_in_operand_to_id;
+	}
+	else
+	{
+		lhs = coerce_in_operand_to_jsonb(pstate, lhs);
+		rewrite = coerce_in_operand_to_jsonb;
+	}
+
+	/* a set operation carries the column in its leaves */
+	if (qtree->setOperations != NULL)
+		rewriteCypherSetOpColumn(pstate, qtree, 0, rewrite);
+	else
+		tle->expr = (Expr *) rewrite(pstate, (Node *) tle->expr);
+
+	return lhs;
+}
+
+/* reduce_graph_elem_to_id() in the shape a set-operation column rewrite takes */
+static Node *
+reduce_in_operand_to_id(ParseState *pstate, Node *expr)
+{
+	return reduce_graph_elem_to_id(pstate, expr, exprLocation(expr));
+}
+
+/*
+ * Coerce an operand of IN to jsonb.  A graph element is serialized whole, as
+ * an array of graph elements is for "x IN [list]", so that a map never equals
+ * a node's properties.
+ */
+static Node *
+coerce_in_operand_to_jsonb(ParseState *pstate, Node *expr)
+{
+	if (is_graph_type(exprType(expr)))
+		return (Node *) makeFuncExpr(F_TO_JSONB, JSONBOID, list_make1(expr),
+									 InvalidOid, InvalidOid,
+									 COERCE_EXPLICIT_CALL);
+
+	return coerce_all_to_jsonb(pstate, expr);
 }
 
 /*

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1964,24 +1964,6 @@ transformSubLink(ParseState *pstate, SubLink *sublink)
 
 	sublink->subselect = (Node *) qtree;
 
-	/*
-	 * "x IN { <cypher> }" compares x, cast to jsonb, with the body's column;
-	 * a column the body returned in its own type is boxed to jsonb here.
-	 */
-	if (sublink->subLinkType == ANY_SUBLINK && IsA(subselect, CypherStmt))
-	{
-		ListCell   *lc;
-
-		foreach(lc, qtree->targetList)
-		{
-			TargetEntry *tent = (TargetEntry *) lfirst(lc);
-
-			if (!tent->resjunk)
-				tent->expr = (Expr *) coerceCypherValueToJsonb(pstate,
-															   (Node *) tent->expr);
-		}
-	}
-
 	if (sublink->subLinkType == EXISTS_SUBLINK)
 	{
 		/*
@@ -2032,9 +2014,15 @@ transformSubLink(ParseState *pstate, SubLink *sublink)
 			sublink->operName = list_make1(makeString("="));
 
 		/*
-		 * Transform lefthand expression, and convert to a list
+		 * Transform lefthand expression, and convert to a list.  The operand
+		 * of "x IN { <cypher> }" is matched to the body's column as well.
 		 */
-		lefthand = transformExprRecurse(pstate, sublink->testexpr);
+		if (sublink->subLinkType == ANY_SUBLINK &&
+			(IsA(subselect, CypherStmt) || isCypherSetOperation(subselect)))
+			lefthand = transformCypherInSubquery(pstate, sublink->testexpr,
+												 qtree);
+		else
+			lefthand = transformExprRecurse(pstate, sublink->testexpr);
 		if (lefthand && IsA(lefthand, RowExpr))
 			left_list = ((RowExpr *) lefthand)->args;
 		else

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -65,4 +65,9 @@ extern List *BuildOnConflictExcludedTargetlist(Relation targetrel,
 
 extern SortGroupClause *makeSortGroupClauseForSetOp(Oid rescoltype, bool require_hash);
 
+typedef Node *(*CypherColumnRewrite) (ParseState *pstate, Node *expr);
+extern bool isCypherSetOperation(Node *stmt);
+extern void rewriteCypherSetOpColumn(ParseState *pstate, Query *qry, int colno,
+									 CypherColumnRewrite rewrite);
+
 #endif							/* ANALYZE_H */

--- a/src/include/parser/parse_cypher_expr.h
+++ b/src/include/parser/parse_cypher_expr.h
@@ -43,6 +43,8 @@ extern List *transformItemList(ParseState *pstate, List *items,
 							   ParseExprKind exprKind);
 extern void resolveItemList(ParseState *pstate, List *items);
 extern Node *coerceCypherValueToJsonb(ParseState *pstate, Node *expr);
+extern Node *transformCypherInSubquery(ParseState *pstate, Node *testexpr,
+									   Query *qtree);
 extern List *transformCypherExprList(ParseState *pstate, List *exprlist,
 									 ParseExprKind exprKind);
 

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -10398,8 +10398,8 @@ RETURN 'Rex' IN { MATCH (:Person)-[:HAS_DOG]->(d:Dog) RETURN d.name } AS no;
  f
 (1 row)
 
--- numeric membership (the left operand is coerced to jsonb to match the jsonb
--- column a cypher RETURN produces)
+-- numeric membership (a value and the column a cypher RETURN produces meet as
+-- jsonb)
 RETURN 35 IN { MATCH (p:Person) RETURN p.age } AS has35;
  has35 
 -------
@@ -10441,6 +10441,95 @@ RETURN p IN { MATCH (q:Person) RETURN q } AS present;
  t
 (1 row)
 
+-- a node, relationship or graphid is matched by identity, as in "x IN [list]":
+-- two vertices with equal properties are still two vertices
+CREATE (:Twin {k: 1}), (:Twin {k: 1});
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+CREATE (a)-[:TWIN_OF {w: 1}]->(b);
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+RETURN a IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n } AS other,
+       a IN { MATCH (n:Twin) WHERE id(n) = id(a) RETURN n } AS self,
+       a NOT IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n } AS not_other;
+ other | self | not_other 
+-------+------+-----------
+ f     | t    | t
+ f     | t    | t
+(2 rows)
+
+MATCH ()-[e:TWIN_OF]->() MATCH ()-[f:TWIN_OF]->() WHERE id(e) <> id(f)
+RETURN e IN { MATCH ()-[g:TWIN_OF]->() WHERE id(g) = id(f) RETURN g } AS other,
+       e IN { MATCH ()-[g:TWIN_OF]->() WHERE id(g) = id(e) RETURN g } AS self;
+ other | self 
+-------+------
+ f     | t
+ f     | t
+(2 rows)
+
+-- either side may be the element or its id
+MATCH (a:Twin) WITH a ORDER BY id(a) LIMIT 1
+RETURN id(a) IN { MATCH (n:Twin) RETURN id(n) } AS id_in_ids,
+       id(a) IN { MATCH (n:Twin) RETURN n } AS id_in_nodes,
+       a IN { MATCH (n:Twin) RETURN id(n) } AS node_in_ids;
+ id_in_ids | id_in_nodes | node_in_ids 
+-----------+-------------+-------------
+ t         | t           | t
+(1 row)
+
+-- in a WHERE the identity test is a semi-join on the id
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+  AND a IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n }
+RETURN count(*) AS none;
+ none 
+------
+ 0
+(1 row)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+MATCH (a:Twin) RETURN a IN { MATCH (n:Twin) RETURN n } AS r;
+                    QUERY PLAN                    
+--------------------------------------------------
+ Seq Scan on exists_subquery.twin a
+   Output: (ANY (a.id = (hashed SubPlan 1).col1))
+   SubPlan 1
+     ->  Seq Scan on exists_subquery.twin n
+           Output: n.id
+(5 rows)
+
+-- the body may be a set operation
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+RETURN a IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n
+              UNION MATCH (n:Twin) WHERE id(n) = id(b) RETURN n } AS other,
+       a IN { MATCH (n:Twin) WHERE id(n) = id(a) RETURN n
+              UNION ALL MATCH (n:Twin) RETURN n } AS self;
+ other | self 
+-------+------
+ f     | t
+ f     | t
+(2 rows)
+
+-- an element is never a member of a set of values, nor a value of a set of
+-- elements
+MATCH (a:Twin) WITH a LIMIT 1 RETURN a IN { MATCH (n:Twin) RETURN n.k } AS r;
+ERROR:  cannot compare graph element identity to type jsonb
+LINE 1: ...ITH a LIMIT 1 RETURN a IN { MATCH (n:Twin) RETURN n.k } AS r...
+                                                             ^
+RETURN 1 IN { MATCH (n:Twin) RETURN n } AS scalar, {k: 1} IN { MATCH (n:Twin) RETURN n } AS map;
+ scalar | map 
+--------+-----
+ f      | f
+(1 row)
+
+-- a path is compared whole
+MATCH p = (a:Twin)-[:TWIN_OF]->(b)
+RETURN p IN { MATCH q = (:Twin)-[:TWIN_OF]->() WHERE id(nodes(q)[0]) = id(a) RETURN q } AS same,
+       p IN { MATCH q = (:Twin)-[:TWIN_OF]->() WHERE id(nodes(q)[0]) <> id(a) RETURN q } AS other;
+ same | other 
+------+-------
+ t    | f
+ t    | f
+(2 rows)
+
+MATCH (t:Twin) DETACH DELETE t;
 -- correlated to the outer row: who owns a dog named 'Fido'
 MATCH (person:Person)
 WHERE 'Fido' IN { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d.name }
@@ -10991,7 +11080,7 @@ LINE 1: RETURN 1 IN { MATCH (a:Person) DETACH DELETE a RETURN a };
                                        ^
 -- cleanup
 DROP GRAPH exists_subquery CASCADE;
-NOTICE:  drop cascades to 12 other objects
+NOTICE:  drop cascades to 14 other objects
 DETAIL:  drop cascades to sequence exists_subquery.ag_label_seq
 drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
@@ -11004,6 +11093,8 @@ drop cascades to elabel has_toy
 drop cascades to vlabel toy
 drop cascades to vlabel summary
 drop cascades to vlabel arrsummary
+drop cascades to vlabel twin
+drop cascades to elabel twin_of
 DROP GRAPH agv2_394 CASCADE;
 NOTICE:  drop cascades to 7 other objects
 DETAIL:  drop cascades to sequence agv2_394.ag_label_seq
@@ -11977,11 +12068,11 @@ EXPLAIN (COSTS OFF) MATCH (a:v {k: 7})-[:e*2..2]-(b:v) RETURN count(*);
 -----------------------------------------------------------
  Aggregate
    ->  Hash Join
-         Hash Cond: ("<0000000802>"._end = b.id)
+         Hash Cond: ("<0000000818>"._end = b.id)
          ->  Nested Loop
                ->  Seq Scan on v a
                      Filter: (properties.'k' = '7'::jsonb)
-               ->  Subquery Scan on "<0000000802>"
+               ->  Subquery Scan on "<0000000818>"
                      ->  Graph VLE on e [2..2]
                            ->  Result
          ->  Hash

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -3928,8 +3928,8 @@ RETURN ARRAY { MATCH (a:Person) DETACH DELETE a RETURN a };
 RETURN 'Fido' IN { MATCH (:Person)-[:HAS_DOG]->(d:Dog) RETURN d.name } AS yes;
 RETURN 'Rex' IN { MATCH (:Person)-[:HAS_DOG]->(d:Dog) RETURN d.name } AS no;
 
--- numeric membership (the left operand is coerced to jsonb to match the jsonb
--- column a cypher RETURN produces)
+-- numeric membership (a value and the column a cypher RETURN produces meet as
+-- jsonb)
 RETURN 35 IN { MATCH (p:Person) RETURN p.age } AS has35;
 RETURN 99 IN { MATCH (p:Person) RETURN p.age } AS has99;
 
@@ -3943,6 +3943,45 @@ RETURN toUpper('fido') IN { MATCH (d:Dog) RETURN toUpper(d.name) } AS yes;
 -- whole-vertex membership (node equality)
 MATCH (p:Person {name: 'Peter'})
 RETURN p IN { MATCH (q:Person) RETURN q } AS present;
+
+-- a node, relationship or graphid is matched by identity, as in "x IN [list]":
+-- two vertices with equal properties are still two vertices
+CREATE (:Twin {k: 1}), (:Twin {k: 1});
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+CREATE (a)-[:TWIN_OF {w: 1}]->(b);
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+RETURN a IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n } AS other,
+       a IN { MATCH (n:Twin) WHERE id(n) = id(a) RETURN n } AS self,
+       a NOT IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n } AS not_other;
+MATCH ()-[e:TWIN_OF]->() MATCH ()-[f:TWIN_OF]->() WHERE id(e) <> id(f)
+RETURN e IN { MATCH ()-[g:TWIN_OF]->() WHERE id(g) = id(f) RETURN g } AS other,
+       e IN { MATCH ()-[g:TWIN_OF]->() WHERE id(g) = id(e) RETURN g } AS self;
+-- either side may be the element or its id
+MATCH (a:Twin) WITH a ORDER BY id(a) LIMIT 1
+RETURN id(a) IN { MATCH (n:Twin) RETURN id(n) } AS id_in_ids,
+       id(a) IN { MATCH (n:Twin) RETURN n } AS id_in_nodes,
+       a IN { MATCH (n:Twin) RETURN id(n) } AS node_in_ids;
+-- in a WHERE the identity test is a semi-join on the id
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+  AND a IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n }
+RETURN count(*) AS none;
+EXPLAIN (VERBOSE, COSTS OFF)
+MATCH (a:Twin) RETURN a IN { MATCH (n:Twin) RETURN n } AS r;
+-- the body may be a set operation
+MATCH (a:Twin), (b:Twin) WHERE id(a) <> id(b)
+RETURN a IN { MATCH (n:Twin) WHERE id(n) = id(b) RETURN n
+              UNION MATCH (n:Twin) WHERE id(n) = id(b) RETURN n } AS other,
+       a IN { MATCH (n:Twin) WHERE id(n) = id(a) RETURN n
+              UNION ALL MATCH (n:Twin) RETURN n } AS self;
+-- an element is never a member of a set of values, nor a value of a set of
+-- elements
+MATCH (a:Twin) WITH a LIMIT 1 RETURN a IN { MATCH (n:Twin) RETURN n.k } AS r;
+RETURN 1 IN { MATCH (n:Twin) RETURN n } AS scalar, {k: 1} IN { MATCH (n:Twin) RETURN n } AS map;
+-- a path is compared whole
+MATCH p = (a:Twin)-[:TWIN_OF]->(b)
+RETURN p IN { MATCH q = (:Twin)-[:TWIN_OF]->() WHERE id(nodes(q)[0]) = id(a) RETURN q } AS same,
+       p IN { MATCH q = (:Twin)-[:TWIN_OF]->() WHERE id(nodes(q)[0]) <> id(a) RETURN q } AS other;
+MATCH (t:Twin) DETACH DELETE t;
 
 -- correlated to the outer row: who owns a dog named 'Fido'
 MATCH (person:Person)


### PR DESCRIPTION
"x IN { <cypher> }" was built as "x::jsonb = ANY (subquery)" before either type was known.  The cast of a node or relationship to jsonb is its property map, so two vertices with the same properties and different ids were "the same" (a IN { MATCH (n) WHERE id(n) = id(b) RETURN n } was true for a <> b, NOT IN was false, a WHERE on it kept the wrong rows), a graphid or a path on the left had no operator at all, and a map literal was a member of a set of nodes whose properties it equalled.  The grammar now hands the operand over as it is, and once the subquery is analyzed the two are matched the way "x IN [list]" matches its operands: a node, relationship or graphid on both sides is reduced to its id, so the planner sees a.id = ANY (SELECT n.id), one on the left against plain values is the same type error the list form raises, and any other pair is compared as jsonb, a graph element serialized whole.  A set-operation body is rewritten in every arm.  The SQL-subquery spelling, which never carried the cast, and the COLLECT { } form were already correct.