### PR TITLE
fix: refuse a subquery body binding that hides an outer variable

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -181,7 +181,8 @@ typedef struct
 
 /* projection (RETURN and WITH) */
 static void checkNameInItems(ParseState *pstate, List *items, List *targetList);
-static void checkCypherLetItems(ParseState *pstate, List *targetList);
+static void checkCypherLetItems(ParseState *pstate, List *items,
+								List *targetList);
 static void updateSortOperatorsForJsonb(List *sortClause, List **targetList,
 										bool allowUnbox, bool allowNativeUnbox);
 static void unboxPromotedGroupKeys(List *groupClause, List **targetList);
@@ -380,6 +381,7 @@ static char *getDeleteTargetName(ParseState *pstate, Node *expr);
 /* CALL */
 static bool nsItemHasColumnNamed(ParseNamespaceItem *nsitem,
 								 const char *colname);
+static bool varBoundInEnclosingQuery(ParseState *pstate, const char *varname);
 static List *joinCallBody(ParseState *pstate,
 						  ParseNamespaceItem *prev_nsitem,
 						  ParseNamespaceItem *body_nsitem, bool optional);
@@ -1211,7 +1213,7 @@ transformCypherProjection(ParseState *pstate, CypherClause *clause)
 		if (detail->kind == CP_WITH)
 			checkNameInItems(pstate, detail->items, qry->targetList);
 		else if (detail->kind == CP_LET)
-			checkCypherLetItems(pstate, qry->targetList);
+			checkCypherLetItems(pstate, detail->items, qry->targetList);
 
 		/*
 		 * Forward each carried element's promoted sentinels through this
@@ -1982,7 +1984,8 @@ transformCypherLoadClause(ParseState *pstate, CypherClause *clause)
 		qry->targetList = makeTargetListFromNSItem(pstate, nsitem);
 	}
 
-	if (findTarget(qry->targetList, rv->alias->aliasname) != NULL)
+	if (findTarget(qry->targetList, rv->alias->aliasname) != NULL ||
+		varBoundInEnclosingQuery(pstate, rv->alias->aliasname))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_ALIAS),
 				 errmsg("duplicate variable \"%s\"", rv->alias->aliasname)));
@@ -2045,7 +2048,8 @@ transformCypherUnwindClause(ParseState *pstate, CypherClause *clause)
 	 *                     ^                ^
 	 *--------------------------
 	 */
-	if (findTarget(qry->targetList, target->name) != NULL)
+	if (findTarget(qry->targetList, target->name) != NULL ||
+		varBoundInEnclosingQuery(pstate, target->name))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_ALIAS),
 				 errmsg("duplicate variable \"%s\"", target->name),
@@ -2141,13 +2145,15 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
 	}
 
 	/* The new variable(s) must not collide with previous ones. */
-	if (findTarget(qry->targetList, strVal(detail->resname)) != NULL)
+	if (findTarget(qry->targetList, strVal(detail->resname)) != NULL ||
+		varBoundInEnclosingQuery(pstate, strVal(detail->resname)))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_ALIAS),
 				 errmsg("duplicate variable \"%s\"", strVal(detail->resname))));
 	if (with_offset &&
 		(strcmp(strVal(detail->resname), strVal(detail->offset)) == 0 ||
-		 findTarget(qry->targetList, strVal(detail->offset)) != NULL))
+		 findTarget(qry->targetList, strVal(detail->offset)) != NULL ||
+		 varBoundInEnclosingQuery(pstate, strVal(detail->offset))))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_ALIAS),
 				 errmsg("duplicate variable \"%s\"", strVal(detail->offset))));
@@ -2511,6 +2517,40 @@ nsItemHasColumnNamed(ParseNamespaceItem *nsitem, const char *colname)
 }
 
 /*
+ * varBoundInEnclosingQuery
+ *		Is a variable of this name in scope from an enclosing query?
+ *
+ *		The body of a subquery expression, or of a CALL with an import list,
+ *		reads the enclosing query's variables through the parent parse states,
+ *		the way column resolution finds them.  A clause that binds a name there
+ *		may not take one of theirs: it would hide the outer variable for the
+ *		rest of the body.
+ */
+static bool
+varBoundInEnclosingQuery(ParseState *pstate, const char *varname)
+{
+	for (pstate = pstate->parentParseState; pstate != NULL;
+		 pstate = pstate->parentParseState)
+	{
+		ListCell   *lc;
+
+		foreach(lc, pstate->p_namespace)
+		{
+			ParseNamespaceItem *nsitem = lfirst(lc);
+
+			if (!nsitem->p_cols_visible)
+				continue;
+			if (nsitem->p_lateral_only && !pstate->p_lateral_active)
+				continue;
+			if (nsItemHasColumnNamed(nsitem, varname))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+/*
  * joinCallBody
  *		Join an analyzed CALL body with the working table and return the
  *		resulting clause target list (the working table's columns followed by
@@ -2860,7 +2900,8 @@ transformCypherCallClause(ParseState *pstate, CypherClause *clause)
 		if (colname[0] == '\0')
 			continue;
 
-		if (nsItemHasColumnNamed(prev_nsitem, colname))
+		if (nsItemHasColumnNamed(prev_nsitem, colname) ||
+			varBoundInEnclosingQuery(pstate, colname))
 			ereport(ERROR,
 					(errcode(ERRCODE_DUPLICATE_ALIAS),
 					 errmsg("variable \"%s\" returned by the CALL subquery is already bound in the outer query",
@@ -3243,6 +3284,35 @@ checkNameInItems(ParseState *pstate, List *items, List *targetList)
 	}
 
 	/*
+	 * A WITH may rename a value it passes on, but not to the name of a
+	 * variable an enclosing query has in scope: inside the body of a subquery
+	 * expression that variable stays readable, and the new one would hide it.
+	 * Passing a variable on under its own name binds nothing new.
+	 */
+	foreach(li, items)
+	{
+		ResTarget  *res = lfirst(li);
+		ColumnRef  *cref;
+
+		if (res->name == NULL)
+			continue;
+
+		cref = IsA(res->val, ColumnRef) ? (ColumnRef *) res->val : NULL;
+		if (cref != NULL && list_length(cref->fields) == 1 &&
+			IsA(linitial(cref->fields), String) &&
+			strcmp(strVal(linitial(cref->fields)), res->name) == 0)
+			continue;
+
+		if (varBoundInEnclosingQuery(pstate, res->name))
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_ALIAS),
+					 errmsg("variable \"%s\" is already bound in the outer query",
+							res->name),
+					 errhint("WITH cannot rebind a variable of the enclosing query; use a different name."),
+					 parser_errposition(pstate, res->location)));
+	}
+
+	/*
 	 * Every value a WITH passes on is named, and a later clause reads it by
 	 * that name, so two of them may not share one: which value a reference
 	 * meant would be a guess.  Walk the target list itself rather than the
@@ -3276,13 +3346,14 @@ checkNameInItems(ParseState *pstate, List *items, List *targetList)
  * checkCypherLetItems
  *		Enforce the two rules that LET adds on top of a plain projection: it is
  *		row-wise (no aggregates) and it may only INTRODUCE names -- it must not
- *		redefine a variable that already exists in the working record, nor bind
- *		the same name twice.  The target list here is the implicit "*" expansion
- *		(every existing binding, always uniquely named) followed by the LET
- *		items, so a duplicate output name can only come from a LET assignment.
+ *		redefine a variable that already exists in the working record or in an
+ *		enclosing query, nor bind the same name twice.  The target list here is
+ *		the implicit "*" expansion (every existing binding, always uniquely
+ *		named) followed by the LET items, so a duplicate output name can only
+ *		come from a LET assignment; the items are the assignments themselves.
  */
 static void
-checkCypherLetItems(ParseState *pstate, List *targetList)
+checkCypherLetItems(ParseState *pstate, List *items, List *targetList)
 {
 	ListCell   *la;
 
@@ -3290,6 +3361,18 @@ checkCypherLetItems(ParseState *pstate, List *targetList)
 		ereport(ERROR,
 				(errcode(ERRCODE_GROUPING_ERROR),
 				 errmsg("aggregate functions are not allowed in LET")));
+
+	foreach(la, items)
+	{
+		ResTarget  *res = lfirst(la);
+
+		if (res->name != NULL && varBoundInEnclosingQuery(pstate, res->name))
+			ereport(ERROR,
+					(errcode(ERRCODE_DUPLICATE_ALIAS),
+					 errmsg("variable \"%s\" already exists", res->name),
+					 errhint("LET cannot redefine an existing variable; use a different name."),
+					 parser_errposition(pstate, res->location)));
+	}
 
 	foreach(la, targetList)
 	{

--- a/src/test/regress/expected/cypher_call.out
+++ b/src/test/regress/expected/cypher_call.out
@@ -532,6 +532,29 @@ RETURN dog;
 ERROR:  variable does not exist
 LINE 2: ...H p MATCH (p)-[:HAS_DOG]->(d:Dog) WHERE d.name <> other.name...
                                                              ^
+-- error: an imported variable cannot be rebound in the body, by LET or by UNWIND
+MATCH (p:Person {name: 'Andy'})
+CALL (p) { LET p = 1 RETURN 1 AS x }
+RETURN x;
+ERROR:  variable "p" already exists
+LINE 2: CALL (p) { LET p = 1 RETURN 1 AS x }
+                       ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (p:Person {name: 'Andy'})
+CALL (p) { UNWIND [1] AS p RETURN 1 AS x }
+RETURN x;
+ERROR:  duplicate variable "p"
+LINE 2: CALL (p) { UNWIND [1] AS p RETURN 1 AS x }
+                          ^
+-- a variable that is not imported is free for the body to bind
+MATCH (p:Person {name: 'Andy'})
+CALL () { UNWIND [1] AS p RETURN p AS x }
+RETURN p.name AS name, x;
+  name  | x 
+--------+---
+ "Andy" | 1
+(1 row)
+
 -- a variable reused inside the body shadows nothing of the outer (uncorrelated)
 MATCH (p:Person {name: 'Andy'})
 CALL () { MATCH (p:Person {name: 'Peter'})-[:HAS_DOG]->(d:Dog) RETURN d.name AS dog }

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -8553,6 +8553,44 @@ RETURN person.name AS name ORDER BY name;
  "Peter"
 (1 row)
 
+-- a body cannot bind a name the enclosing query has in scope: the outer
+-- variable stays readable inside, so the new one would hide it
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { UNWIND [1, 2] AS person RETURN person } AS c;
+ERROR:  duplicate variable "person"
+LINE 2: RETURN COUNT { UNWIND [1, 2] AS person RETURN person } AS c;
+                              ^
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { FOR person IN [1, 2] RETURN person } AS c;
+ERROR:  duplicate variable "person"
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { MATCH (d:Dog) WITH d AS person RETURN person } AS c;
+ERROR:  variable "person" is already bound in the outer query
+LINE 2: RETURN COUNT { MATCH (d:Dog) WITH d AS person RETURN person ...
+                                          ^
+HINT:  WITH cannot rebind a variable of the enclosing query; use a different name.
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { MATCH (d:Dog) WITH d.name AS person RETURN person } AS c;
+ERROR:  variable "person" is already bound in the outer query
+LINE 2: RETURN COUNT { MATCH (d:Dog) WITH d.name AS person RETURN pe...
+                                          ^
+HINT:  WITH cannot rebind a variable of the enclosing query; use a different name.
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { CALL () { RETURN 1 AS person } RETURN person } AS c;
+ERROR:  variable "person" returned by the CALL subquery is already bound in the outer query
+LINE 2: RETURN COUNT { CALL () { RETURN 1 AS person } RETURN person ...
+                       ^
+-- a bound reference to the outer variable, passing it on under its own name,
+-- WITH *, and a RETURN alias bind nothing new
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { MATCH (person)-[:HAS_DOG]->(d:Dog) WITH person, d RETURN d } AS bound,
+       COUNT { MATCH (person)-[:HAS_DOG]->(d:Dog) WITH * RETURN d } AS star,
+       COUNT { MATCH (d:Dog) RETURN d AS person } AS alias;
+ bound | star | alias 
+-------+------+-------
+ 2     | 2    | 3
+(1 row)
+
 -- inner WHERE referencing both outer and inner variables
 MATCH (person:Person)
 RETURN person.name AS name,
@@ -12068,11 +12106,11 @@ EXPLAIN (COSTS OFF) MATCH (a:v {k: 7})-[:e*2..2]-(b:v) RETURN count(*);
 -----------------------------------------------------------
  Aggregate
    ->  Hash Join
-         Hash Cond: ("<0000000818>"._end = b.id)
+         Hash Cond: ("<0000000820>"._end = b.id)
          ->  Nested Loop
                ->  Seq Scan on v a
                      Filter: (properties.'k' = '7'::jsonb)
-               ->  Subquery Scan on "<0000000818>"
+               ->  Subquery Scan on "<0000000820>"
                      ->  Graph VLE on e [2..2]
                            ->  Result
          ->  Hash

--- a/src/test/regress/expected/cypher_let.out
+++ b/src/test/regress/expected/cypher_let.out
@@ -216,6 +216,103 @@ LET z = 1, z = 2
 RETURN z;
 ERROR:  variable "z" already exists
 HINT:  LET cannot redefine an existing variable; use a different name.
+-- Rebinding a variable of the enclosing query inside the body of a subquery
+-- expression: the body reads the outer variable, so the name is taken.  Every
+-- body form, a leading and a following LET, a body in WHERE, two levels down.
+MATCH (n:person {id: 1})
+RETURN COUNT { LET n = 1 RETURN n } AS c;
+ERROR:  variable "n" already exists
+LINE 2: RETURN COUNT { LET n = 1 RETURN n } AS c;
+                           ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+RETURN EXISTS { MATCH (m:person) LET n = 1 RETURN m } AS e;
+ERROR:  variable "n" already exists
+LINE 2: RETURN EXISTS { MATCH (m:person) LET n = 1 RETURN m } AS e;
+                                             ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+RETURN COLLECT { LET n = 1 RETURN n } AS l;
+ERROR:  variable "n" already exists
+LINE 2: RETURN COLLECT { LET n = 1 RETURN n } AS l;
+                             ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+RETURN VALUE { LET n = 1 RETURN n } AS v;
+ERROR:  variable "n" already exists
+LINE 2: RETURN VALUE { LET n = 1 RETURN n } AS v;
+                           ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+RETURN ARRAY { LET n = 1 RETURN n } AS a;
+ERROR:  variable "n" already exists
+LINE 2: RETURN ARRAY { LET n = 1 RETURN n } AS a;
+                           ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+RETURN 1 IN { LET n = 1 RETURN n } AS i;
+ERROR:  variable "n" already exists
+LINE 2: RETURN 1 IN { LET n = 1 RETURN n } AS i;
+                          ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+WHERE COUNT { LET n = 1 RETURN n } > 0
+RETURN n.name;
+ERROR:  variable "n" already exists
+LINE 2: WHERE COUNT { LET n = 1 RETURN n } > 0
+                          ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (n:person {id: 1})
+RETURN COUNT { MATCH (m:person) RETURN COUNT { LET n = 1 RETURN n } } AS nested;
+ERROR:  variable "n" already exists
+LINE 2: ...ETURN COUNT { MATCH (m:person) RETURN COUNT { LET n = 1 RETU...
+                                                             ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+-- An edge, a path and a WITH-bound name are taken as well.
+MATCH (a:person)-[k:knows]->(b:person)
+RETURN COUNT { LET k = 1 RETURN k } AS c;
+ERROR:  variable "k" already exists
+LINE 2: RETURN COUNT { LET k = 1 RETURN k } AS c;
+                           ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH p = (a:person)-[:knows]->(b:person)
+RETURN COUNT { LET p = 1 RETURN p } AS c;
+ERROR:  variable "p" already exists
+LINE 2: RETURN COUNT { LET p = 1 RETURN p } AS c;
+                           ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+MATCH (a:person {id: 1}) WITH a.name AS nm
+RETURN COUNT { LET nm = 1 RETURN nm } AS c;
+ERROR:  variable "nm" already exists
+LINE 2: RETURN COUNT { LET nm = 1 RETURN nm } AS c;
+                           ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+-- A CALL body that imports the variable cannot rebind it either ...
+MATCH (n:person {id: 1})
+CALL (n) { LET n = 1 RETURN 1 AS x }
+RETURN x;
+ERROR:  variable "n" already exists
+LINE 2: CALL (n) { LET n = 1 RETURN 1 AS x }
+                       ^
+HINT:  LET cannot redefine an existing variable; use a different name.
+-- ... while one that does not import it may use the name.
+MATCH (n:person {id: 1})
+CALL () { LET n = 1 RETURN n AS x }
+RETURN n.name AS name, x;
+  name   | x 
+---------+---
+ "alice" | 1
+(1 row)
+
+-- Inside a body, a bound reference to the outer variable and a fresh name are
+-- fine.
+MATCH (n:person {id: 1})
+RETURN COUNT { MATCH (n)-[:knows]->(m) LET d = m.age * 2 RETURN d } AS c;
+ c 
+---
+ 1
+(1 row)
+
 -- A plain aggregate in LET.
 MATCH (n:person)
 LET c = count(*)

--- a/src/test/regress/sql/cypher_call.sql
+++ b/src/test/regress/sql/cypher_call.sql
@@ -261,6 +261,17 @@ RETURN dog;
 MATCH (p:Person {name: 'Andy'}), (other:Person {name: 'Peter'})
 CALL { WITH p MATCH (p)-[:HAS_DOG]->(d:Dog) WHERE d.name <> other.name RETURN d.name AS dog }
 RETURN dog;
+-- error: an imported variable cannot be rebound in the body, by LET or by UNWIND
+MATCH (p:Person {name: 'Andy'})
+CALL (p) { LET p = 1 RETURN 1 AS x }
+RETURN x;
+MATCH (p:Person {name: 'Andy'})
+CALL (p) { UNWIND [1] AS p RETURN 1 AS x }
+RETURN x;
+-- a variable that is not imported is free for the body to bind
+MATCH (p:Person {name: 'Andy'})
+CALL () { UNWIND [1] AS p RETURN p AS x }
+RETURN p.name AS name, x;
 -- a variable reused inside the body shadows nothing of the outer (uncorrelated)
 MATCH (p:Person {name: 'Andy'})
 CALL () { MATCH (p:Person {name: 'Peter'})-[:HAS_DOG]->(d:Dog) RETURN d.name AS dog }

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -3024,6 +3024,25 @@ MATCH (person:Person)
 WHERE COUNT { (person)-[:HAS_DOG]->(:Dog) } > 1
 RETURN person.name AS name ORDER BY name;
 
+-- a body cannot bind a name the enclosing query has in scope: the outer
+-- variable stays readable inside, so the new one would hide it
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { UNWIND [1, 2] AS person RETURN person } AS c;
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { FOR person IN [1, 2] RETURN person } AS c;
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { MATCH (d:Dog) WITH d AS person RETURN person } AS c;
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { MATCH (d:Dog) WITH d.name AS person RETURN person } AS c;
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { CALL () { RETURN 1 AS person } RETURN person } AS c;
+-- a bound reference to the outer variable, passing it on under its own name,
+-- WITH *, and a RETURN alias bind nothing new
+MATCH (person:Person {name: 'Peter'})
+RETURN COUNT { MATCH (person)-[:HAS_DOG]->(d:Dog) WITH person, d RETURN d } AS bound,
+       COUNT { MATCH (person)-[:HAS_DOG]->(d:Dog) WITH * RETURN d } AS star,
+       COUNT { MATCH (d:Dog) RETURN d AS person } AS alias;
+
 -- inner WHERE referencing both outer and inner variables
 MATCH (person:Person)
 RETURN person.name AS name,

--- a/src/test/regress/sql/cypher_let.sql
+++ b/src/test/regress/sql/cypher_let.sql
@@ -166,6 +166,49 @@ MATCH (n:person {id: 1})
 LET z = 1, z = 2
 RETURN z;
 
+-- Rebinding a variable of the enclosing query inside the body of a subquery
+-- expression: the body reads the outer variable, so the name is taken.  Every
+-- body form, a leading and a following LET, a body in WHERE, two levels down.
+MATCH (n:person {id: 1})
+RETURN COUNT { LET n = 1 RETURN n } AS c;
+MATCH (n:person {id: 1})
+RETURN EXISTS { MATCH (m:person) LET n = 1 RETURN m } AS e;
+MATCH (n:person {id: 1})
+RETURN COLLECT { LET n = 1 RETURN n } AS l;
+MATCH (n:person {id: 1})
+RETURN VALUE { LET n = 1 RETURN n } AS v;
+MATCH (n:person {id: 1})
+RETURN ARRAY { LET n = 1 RETURN n } AS a;
+MATCH (n:person {id: 1})
+RETURN 1 IN { LET n = 1 RETURN n } AS i;
+MATCH (n:person {id: 1})
+WHERE COUNT { LET n = 1 RETURN n } > 0
+RETURN n.name;
+MATCH (n:person {id: 1})
+RETURN COUNT { MATCH (m:person) RETURN COUNT { LET n = 1 RETURN n } } AS nested;
+
+-- An edge, a path and a WITH-bound name are taken as well.
+MATCH (a:person)-[k:knows]->(b:person)
+RETURN COUNT { LET k = 1 RETURN k } AS c;
+MATCH p = (a:person)-[:knows]->(b:person)
+RETURN COUNT { LET p = 1 RETURN p } AS c;
+MATCH (a:person {id: 1}) WITH a.name AS nm
+RETURN COUNT { LET nm = 1 RETURN nm } AS c;
+
+-- A CALL body that imports the variable cannot rebind it either ...
+MATCH (n:person {id: 1})
+CALL (n) { LET n = 1 RETURN 1 AS x }
+RETURN x;
+-- ... while one that does not import it may use the name.
+MATCH (n:person {id: 1})
+CALL () { LET n = 1 RETURN n AS x }
+RETURN n.name AS name, x;
+
+-- Inside a body, a bound reference to the outer variable and a fresh name are
+-- fine.
+MATCH (n:person {id: 1})
+RETURN COUNT { MATCH (n)-[:knows]->(m) LET d = m.age * 2 RETURN d } AS c;
+
 -- A plain aggregate in LET.
 MATCH (n:person)
 LET c = count(*)


### PR DESCRIPTION
Fixes AGV2-579
#note A LET, UNWIND, FOR, WITH alias or CALL result inside a subquery expression body or an importing CALL body can no longer take the name of a variable the enclosing query has in scope. #devdone

The body of EXISTS { }, COUNT { }, COLLECT { }, VALUE { }, ARRAY { } and x IN { } reads the variables in scope where it is written, and the body of CALL (n) { } reads what it imports.  Every check that a clause may bind a name compared it with the body's own working table only, so LET n = 1, UNWIND ... AS n, FOR n IN ..., WITH m AS n and CALL () { RETURN 1 AS n } inside a body silently bound a second n over the enclosing one, whatever the outer n was and however deep the body sat, while the same clauses at the top level are refused.  A predicate written against the outer variable was then evaluated against the new one with no error.

A name a clause introduces is now also compared with what the enclosing queries have in scope, through the parent parse states, which is where column resolution finds those variables.  LET reports the variable as existing, as it does at the top level; UNWIND, FOR and LOAD report a duplicate variable; a CALL body's returned name is reported as already bound; a WITH that renames a value to such a name is refused with its own message, while WITH n and WITH * pass a variable on under its own name and bind nothing new.  A MATCH on the name stays a bound reference, a RETURN alias in a body binds nothing, and an uncorrelated CALL () may use the name. GQL 10.3 and 14.8 state the rule for a value variable definition and for FOR; Cypher 25 refuses every one of these shapes as variable shadowing.