### PR TITLE
fix: expand a list of graph elements with FOR as the elements

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -399,6 +399,7 @@ static bool find_target_label_walker(Node *node,
 
 /* common */
 static ParseNamespaceItem *addUnitRowNSItem(ParseState *pstate);
+static List *makeForClauseTargetList(Query *subqry, CypherForClause *detail);
 static bool labelExist(ParseState *pstate, char *labname, int labloc,
 					   char labkind, bool throw);
 #define vertexLabelExist(pstate, labname, labloc) \
@@ -2116,8 +2117,10 @@ transformCypherUnwindClause(ParseState *pstate, CypherClause *clause)
  *		The array expression is unnested as a LATERAL set-returning function
  *		joined with the working table, optionally exposing each element's
  *		0-based position via WITH OFFSET.  The expression is wrapped in a
- *		CypherGenericExpr so it is transformed in Cypher context (yielding a
- *		jsonb array) inside the SQL subquery.
+ *		CypherGenericExpr so it is transformed in Cypher context (a jsonb list,
+ *		or a native list of nodes, relationships or paths) inside the SQL
+ *		subquery; the subquery's output is then built from the function's
+ *		columns by makeForClauseTargetList().
  */
 Query *
 transformCypherForClause(ParseState *pstate, CypherClause *clause)
@@ -2129,7 +2132,6 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
 	CypherGenericExpr *cge;
 	RangeFunction *rf;
 	SelectStmt *subquery;
-	List	   *colnames;
 	List	   *targetList;
 	ParseNamespaceItem *nsitem;
 	bool		with_offset = (detail->offset != NULL);
@@ -2187,14 +2189,12 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
 	cge = makeNode(CypherGenericExpr);
 	cge->expr = source;
 
-	colnames = list_make1(detail->resname);
-	targetList = list_make1(makeResTarget(makeColumnRef(list_make1(detail->resname)),
+	/* SELECT * [, ordinality - 1 AS offset] FROM unnest(array) [WITH ORDINALITY] */
+	targetList = list_make1(makeResTarget(makeColumnRef(list_make1(makeNode(A_Star))),
 										  NULL));
 	if (with_offset)
 	{
 		Node	   *zero_based;
-
-		colnames = lappend(colnames, detail->offset);
 
 		/*
 		 * Per the GQL standard the offset is 0-based, but the ordinality
@@ -2202,14 +2202,14 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
 		 * - 1) under the offset variable's name.
 		 */
 		zero_based = (Node *) makeSimpleA_Expr(AEXPR_OP, "-",
-											   makeColumnRef(list_make1(detail->offset)),
+											   makeColumnRef(list_make1(makeString("ordinality"))),
 											   makeIntConst(1, -1), -1);
 		targetList = lappend(targetList,
 							 makeResTarget(zero_based, strVal(detail->offset)));
 	}
 
 	rf = makeRangeFunction(list_make1(makeString("unnest")), (Node *) cge,
-						   makeAliasNoDup(AGENS_DEFAULT_PREFIX "for", colnames),
+						   makeAliasNoDup(AGENS_DEFAULT_PREFIX "for", NIL),
 						   with_offset);
 
 	subquery = makeNode(SelectStmt);
@@ -2226,6 +2226,8 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
 	pstate->p_lateral_active = (clause->prev != NULL);
 
 	subqry = parse_sub_analyze((Node *) subquery, pstate, NULL, false, true);
+
+	subqry->targetList = makeForClauseTargetList(subqry, detail);
 
 	nsitem = addRangeTableEntryForSubquery(pstate, subqry,
 										   makeAliasNoDup(CYPHER_FOR_ALIAS, NIL),
@@ -2249,6 +2251,60 @@ transformCypherForClause(ParseState *pstate, CypherClause *clause)
 	assign_query_collations(pstate, qry);
 
 	return qry;
+}
+
+/*
+ * makeForClauseTargetList
+ *		Build the output of a FOR clause's unnest subquery: the element under
+ *		the FOR variable's name, and the offset when one was asked for.
+ *
+ *		subqry is the analyzed SELECT * over the function scan.  A function
+ *		returning a row type is expanded into one column per field there, so
+ *		the element is put back together as a row of that type; a scalar
+ *		element is its single column.  The offset expression, when present,
+ *		is the last entry already.
+ */
+static List *
+makeForClauseTargetList(Query *subqry, CypherForClause *detail)
+{
+	RangeTblEntry *rte = rt_fetch(1, subqry->rtable);
+	RangeTblFunction *rtf = linitial(rte->functions);
+	Oid			elemtype = exprType(rtf->funcexpr);
+	Node	   *elem;
+	List	   *result;
+
+	Assert(rte->rtekind == RTE_FUNCTION);
+
+	if (type_is_rowtype(elemtype))
+	{
+		List	   *fields = NIL;
+		int			i;
+
+		for (i = 0; i < rtf->funccolcount; i++)
+		{
+			TargetEntry *te = list_nth(subqry->targetList, i);
+
+			fields = lappend(fields, te->expr);
+		}
+		elem = makeTypedRowExpr(fields, elemtype, exprLocation(detail->expr));
+	}
+	else
+	{
+		Assert(rtf->funccolcount == 1);
+		elem = (Node *) ((TargetEntry *) linitial(subqry->targetList))->expr;
+	}
+
+	result = list_make1(makeTargetEntry((Expr *) elem, 1,
+										strVal(detail->resname), false));
+	if (detail->offset != NULL)
+	{
+		TargetEntry *offset = llast(subqry->targetList);
+
+		result = lappend(result, makeTargetEntry(offset->expr, 2,
+												 offset->resname, false));
+	}
+
+	return result;
 }
 
 /*

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -8082,6 +8082,71 @@ ORDER BY Id, alert_type, "offset";
  3  | "some"     | 1
 (6 rows)
 
+-- == a list of nodes, relationships or paths ==
+-- the element comes out as itself, as it does through UNWIND: a path's
+-- vertices and edges, a collected list, a list literal, a COLLECT subquery
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR v in vertices(p) RETURN v, pg_typeof(v);
+                             v                             | pg_typeof 
+-----------------------------------------------------------+-----------
+ person[3.1]{"id": 1, "name": "Alice", "tags": ["x", "y"]} | "vertex"
+ account[5.1]{"no": 100}                                   | "vertex"
+(2 rows)
+
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR e in edges(p) RETURN e, pg_typeof(e);
+          e           | pg_typeof 
+----------------------+-----------
+ owns[4.1][3.1,5.1]{} | "edge"
+(1 row)
+
+MATCH (p:Person) WITH collect(p) AS ps FOR v in ps RETURN v.name AS name ORDER BY name;
+  name   
+---------
+ "Alice"
+ "Bob"
+ "Carol"
+(3 rows)
+
+MATCH (p:Person {Id: 1}) FOR v in [p] RETURN v.name AS name, label(v) AS label;
+  name   |  label   
+---------+----------
+ "Alice" | "person"
+(1 row)
+
+MATCH (p:Person {Id: 1}) FOR v in COLLECT { MATCH (a:Account) RETURN a } RETURN v.no AS no ORDER BY no;
+ no  
+-----
+ 100
+ 200
+ 300
+(3 rows)
+
+-- the element and its offset over a list of nodes
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR v in vertices(p) WITH OFFSET AS i RETURN i, label(v) AS label ORDER BY i;
+ i |   label   
+---+-----------
+ 0 | "person"
+ 1 | "account"
+(2 rows)
+
+-- the element is usable as a node afterwards: a following MATCH from it
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR v in vertices(p) MATCH (v)-[:Owns]->(a:Account) RETURN a.no AS no;
+ no  
+-----
+ 100
+(1 row)
+
+-- a list of paths
+MATCH p = (:Person)-[:Owns]->(:Account) WITH collect(p) AS ps
+FOR q in ps RETURN length(q) AS len, pg_typeof(q) ORDER BY len LIMIT 1;
+ len |  pg_typeof  
+-----+-------------
+ 1   | "graphpath"
+(1 row)
+
 -- == composition / chaining ==
 -- standalone FOR, then WITH, then RETURN
 FOR x in [1,2,3] WITH x AS col RETURN col ORDER BY col;
@@ -12106,11 +12171,11 @@ EXPLAIN (COSTS OFF) MATCH (a:v {k: 7})-[:e*2..2]-(b:v) RETURN count(*);
 -----------------------------------------------------------
  Aggregate
    ->  Hash Join
-         Hash Cond: ("<0000000820>"._end = b.id)
+         Hash Cond: ("<0000000836>"._end = b.id)
          ->  Nested Loop
                ->  Seq Scan on v a
                      Filter: (properties.'k' = '7'::jsonb)
-               ->  Subquery Scan on "<0000000820>"
+               ->  Subquery Scan on "<0000000836>"
                      ->  Graph VLE on e [2..2]
                            ->  Result
          ->  Hash

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -2805,6 +2805,26 @@ FOR alert in ['all','some'] WITH OFFSET
 RETURN p.Id, alert AS alert_type, "offset"
 ORDER BY Id, alert_type, "offset";
 
+-- == a list of nodes, relationships or paths ==
+-- the element comes out as itself, as it does through UNWIND: a path's
+-- vertices and edges, a collected list, a list literal, a COLLECT subquery
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR v in vertices(p) RETURN v, pg_typeof(v);
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR e in edges(p) RETURN e, pg_typeof(e);
+MATCH (p:Person) WITH collect(p) AS ps FOR v in ps RETURN v.name AS name ORDER BY name;
+MATCH (p:Person {Id: 1}) FOR v in [p] RETURN v.name AS name, label(v) AS label;
+MATCH (p:Person {Id: 1}) FOR v in COLLECT { MATCH (a:Account) RETURN a } RETURN v.no AS no ORDER BY no;
+-- the element and its offset over a list of nodes
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR v in vertices(p) WITH OFFSET AS i RETURN i, label(v) AS label ORDER BY i;
+-- the element is usable as a node afterwards: a following MATCH from it
+MATCH p = (:Person {Id: 1})-[:Owns]->(:Account)
+FOR v in vertices(p) MATCH (v)-[:Owns]->(a:Account) RETURN a.no AS no;
+-- a list of paths
+MATCH p = (:Person)-[:Owns]->(:Account) WITH collect(p) AS ps
+FOR q in ps RETURN length(q) AS len, pg_typeof(q) ORDER BY len LIMIT 1;
+
 -- == composition / chaining ==
 -- standalone FOR, then WITH, then RETURN
 FOR x in [1,2,3] WITH x AS col RETURN col ORDER BY col;


### PR DESCRIPTION
FOR unnests its list through unnest() in the FROM of a subquery, and named the function's first output column with the FOR variable.  For a jsonb list that column is the element.  For a list of nodes, relationships or paths the function's result is a row type, which a function scan expands into one column per field, so the FOR variable was bound to the id column and a graphid surfaced where UNWIND over the same list yields the element: FOR v IN vertices(p), edges(p), collect(n), [n] or COLLECT { } all did, and WITH OFFSET named its variable over the second field, so an offset over a list of nodes failed as a jsonb subtraction.

The subquery now selects every column of the function scan, and its output is built afterwards from what the function returned: a row type is put back together as a row of that type, a scalar is its one column, and the offset is computed from the ordinality column by its own name.  A jsonb list keeps the same plan; EXPLAIN VERBOSE shows the function's own column name inside it where it used to show the FOR variable.