### PR TITLE
fix: let DROP INDEX drop a property index

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1643,15 +1643,17 @@ RemoveRelations(DropStmt *drop)
 		}
 
 
+		/*
+		 * DROP PROPERTY INDEX is the graph DDL and takes only an index over
+		 * properties.  DROP INDEX takes any index, one on a label included:
+		 * an index a plain CREATE INDEX made on a label is dropped the same
+		 * way it was made.
+		 */
 		if (drop->removeType == OBJECT_PROPERTY_INDEX &&
 			!isPropertyIndex(relOid))
 			ereport(ERROR,
 					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 					 errmsg("\"%s\" is not property index", rel->relname)));
-		if (drop->removeType == OBJECT_INDEX && isPropertyIndex(relOid))
-			ereport(ERROR,
-					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-					 errmsg("\"%s\" is property index", rel->relname)));
 
 		/*
 		 * Decide if concurrent mode needs to be used here or not.  The

--- a/src/test/regress/expected/cypher_typed_column.out
+++ b/src/test/regress/expected/cypher_typed_column.out
@@ -599,9 +599,7 @@ MATCH (n:doc) RETURN n.age + 1 AS a, count(*) AS c ORDER BY a LIMIT 2;
 (10 rows)
 
 DROP INDEX tc.idx_agex;
-ERROR:  "idx_agex" is property index
 DROP INDEX tc.idx_lowertitle;
-ERROR:  "idx_lowertitle" is property index
 ANALYZE tc.doc;
 SET enable_seqscan = on;
 -- ============================================================================

--- a/src/test/regress/expected/propertyindex.out
+++ b/src/test/regress/expected/propertyindex.out
@@ -313,13 +313,92 @@ CREATE PROPERTY INDEX ON nonexsist_name (key1);
 ERROR:  label "nonexsist_name" does not exist
 DROP VLABEL piv8;
 CREATE VLABEL piv9;
-CREATE PROPERTY INDEX piv9_property_index_key1 ON piv9 (key1);
-DROP INDEX propidx.piv9_property_index_key1;
-ERROR:  "piv9_property_index_key1" is property index
+-- an index that is not over properties is not the graph DDL's to drop
 CREATE INDEX piv9_index_key1 ON propidx.piv9 (properties);
 DROP PROPERTY INDEX piv9_index_key1;
 ERROR:  "piv9_index_key1" is not property index
+DROP INDEX propidx.piv9_index_key1;
 DROP VLABEL piv9;
+-- Plain SQL spelling of a property index
+--
+-- A property index stores properties.'key', and that is what a Cypher filter
+-- on the property compiles to.  The same spelling is accepted by a plain
+-- CREATE INDEX, so an index made either way is one the filter uses, and the
+-- definition pg_get_indexdef prints runs as written.  Either statement drops
+-- such an index; DROP PROPERTY INDEX alone is refused an index that is not
+-- over properties.
+CREATE VLABEL piv13;
+UNWIND range(1, 200) AS i CREATE (:piv13 {k: 'k' + toString(i), n: i % 10, m: {a: i}});
+ANALYZE propidx.piv13;
+CREATE PROPERTY INDEX piv13_prop ON piv13 (k);
+CREATE INDEX piv13_sql ON propidx.piv13 ((properties.'k'));
+CREATE INDEX piv13_two ON propidx.piv13 ((properties.'k'), (properties.'n'));
+CREATE INDEX piv13_nested ON propidx.piv13 ((properties.'m'.'a'));
+SELECT indexrelid::regclass AS index, pg_get_expr(indexprs, indrelid) AS expression
+FROM pg_index WHERE indrelid = 'propidx.piv13'::regclass AND indexprs IS NOT NULL
+ORDER BY 1;
+        index         |           expression           
+----------------------+--------------------------------
+ propidx.piv13_prop   | properties.'k'
+ propidx.piv13_sql    | properties.'k'
+ propidx.piv13_two    | properties.'k', properties.'n'
+ propidx.piv13_nested | properties.'m'.'a'
+(4 rows)
+
+SELECT pg_get_indexdef('propidx.piv13_sql'::regclass);
+                            pg_get_indexdef                             
+------------------------------------------------------------------------
+ CREATE INDEX piv13_sql ON propidx.piv13 USING btree ((properties.'k'))
+(1 row)
+
+DROP PROPERTY INDEX piv13_prop;
+-- the filter uses the index written in SQL: one key, a nested key
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF) MATCH (n:piv13) WHERE n.k = 'k7' RETURN n;
+                   QUERY PLAN                   
+------------------------------------------------
+ Index Scan using piv13_sql on piv13 n
+   Index Cond: (properties.'k' = '"k7"'::jsonb)
+(2 rows)
+
+EXPLAIN (COSTS OFF) MATCH (n:piv13) WHERE n.m.a = 7 RETURN n;
+                   QUERY PLAN                    
+-------------------------------------------------
+ Index Scan using piv13_nested on piv13 n
+   Index Cond: (properties.'m'.'a' = '7'::jsonb)
+(2 rows)
+
+-- the printed definition, run under a new name, is the same index
+CREATE INDEX piv13_again ON propidx.piv13 USING btree ((properties.'k'));
+SELECT pg_get_expr(indexprs, indrelid) FROM pg_index WHERE indexrelid = 'propidx.piv13_again'::regclass;
+  pg_get_expr   
+----------------
+ properties.'k'
+(1 row)
+
+-- either statement drops an index over properties, whichever statement made it
+DROP INDEX propidx.piv13_sql;
+DROP PROPERTY INDEX piv13_again;
+CREATE PROPERTY INDEX piv13_prop ON piv13 (k);
+DROP INDEX propidx.piv13_prop;
+-- with the single-key indexes gone, two keys are served by the two-key index
+EXPLAIN (COSTS OFF) MATCH (n:piv13) WHERE n.k = 'k7' AND n.n = 7 RETURN n;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Index Scan using piv13_two on piv13 n
+   Index Cond: ((properties.'k' = '"k7"'::jsonb) AND (properties.'n' = '7'::jsonb))
+(2 rows)
+
+RESET enable_seqscan;
+DROP INDEX propidx.piv13_two, propidx.piv13_nested;
+\dGi piv13*
+                 List of property indexes
+ Graph | LabelName | IndexName | Unique | Owner | Indexdef 
+-------+-----------+-----------+--------+-------+----------
+(0 rows)
+
+MATCH (n:piv13) DELETE n;
+DROP VLABEL piv13;
 -- Subscripted property keys
 --
 -- A subscript is the name of the property being read only where it is a string.

--- a/src/test/regress/sql/propertyindex.sql
+++ b/src/test/regress/sql/propertyindex.sql
@@ -134,13 +134,58 @@ DROP VLABEL piv8;
 
 CREATE VLABEL piv9;
 
-CREATE PROPERTY INDEX piv9_property_index_key1 ON piv9 (key1);
-DROP INDEX propidx.piv9_property_index_key1;
-
+-- an index that is not over properties is not the graph DDL's to drop
 CREATE INDEX piv9_index_key1 ON propidx.piv9 (properties);
 DROP PROPERTY INDEX piv9_index_key1;
+DROP INDEX propidx.piv9_index_key1;
 
 DROP VLABEL piv9;
+
+-- Plain SQL spelling of a property index
+--
+-- A property index stores properties.'key', and that is what a Cypher filter
+-- on the property compiles to.  The same spelling is accepted by a plain
+-- CREATE INDEX, so an index made either way is one the filter uses, and the
+-- definition pg_get_indexdef prints runs as written.  Either statement drops
+-- such an index; DROP PROPERTY INDEX alone is refused an index that is not
+-- over properties.
+CREATE VLABEL piv13;
+UNWIND range(1, 200) AS i CREATE (:piv13 {k: 'k' + toString(i), n: i % 10, m: {a: i}});
+ANALYZE propidx.piv13;
+
+CREATE PROPERTY INDEX piv13_prop ON piv13 (k);
+CREATE INDEX piv13_sql ON propidx.piv13 ((properties.'k'));
+CREATE INDEX piv13_two ON propidx.piv13 ((properties.'k'), (properties.'n'));
+CREATE INDEX piv13_nested ON propidx.piv13 ((properties.'m'.'a'));
+SELECT indexrelid::regclass AS index, pg_get_expr(indexprs, indrelid) AS expression
+FROM pg_index WHERE indrelid = 'propidx.piv13'::regclass AND indexprs IS NOT NULL
+ORDER BY 1;
+SELECT pg_get_indexdef('propidx.piv13_sql'::regclass);
+DROP PROPERTY INDEX piv13_prop;
+
+-- the filter uses the index written in SQL: one key, a nested key
+SET enable_seqscan = off;
+EXPLAIN (COSTS OFF) MATCH (n:piv13) WHERE n.k = 'k7' RETURN n;
+EXPLAIN (COSTS OFF) MATCH (n:piv13) WHERE n.m.a = 7 RETURN n;
+
+-- the printed definition, run under a new name, is the same index
+CREATE INDEX piv13_again ON propidx.piv13 USING btree ((properties.'k'));
+SELECT pg_get_expr(indexprs, indrelid) FROM pg_index WHERE indexrelid = 'propidx.piv13_again'::regclass;
+
+-- either statement drops an index over properties, whichever statement made it
+DROP INDEX propidx.piv13_sql;
+DROP PROPERTY INDEX piv13_again;
+CREATE PROPERTY INDEX piv13_prop ON piv13 (k);
+DROP INDEX propidx.piv13_prop;
+
+-- with the single-key indexes gone, two keys are served by the two-key index
+EXPLAIN (COSTS OFF) MATCH (n:piv13) WHERE n.k = 'k7' AND n.n = 7 RETURN n;
+RESET enable_seqscan;
+DROP INDEX propidx.piv13_two, propidx.piv13_nested;
+\dGi piv13*
+
+MATCH (n:piv13) DELETE n;
+DROP VLABEL piv13;
 
 -- Subscripted property keys
 --


### PR DESCRIPTION
When this was filed, the expression a property index stores, properties.'key', could not be written in a plain CREATE INDEX, so nothing that composes an index definition could produce an index a Cypher filter would use, and the definition pg_get_indexdef printed would not run.  Since be5506ccce2 the SQL grammar reads .'key' as a property of a map: CREATE INDEX ... ((properties.'k')) stores the same expression as CREATE PROPERTY INDEX, the filter uses it, and the printed definition runs as written.  Whatever a tool built on top of that still gets wrong is on its side.  propertyindex gains a section that pins this for one key, two keys and a nested key.

One asymmetry stayed: an index on a label could be made with CREATE INDEX but dropped only with DROP PROPERTY INDEX, because DROP INDEX has refused every property index since 2017.  A tool that creates an index the SQL way could not remove it the same way.  DROP INDEX now drops any index of a label; DROP PROPERTY INDEX is the graph DDL and still takes only an index over properties.