### PR TITLE
fix: report graph_path to the client

### DIFF
--- a/doc/src/sgml/libpq.sgml
+++ b/doc/src/sgml/libpq.sgml
@@ -2874,10 +2874,12 @@ const char *PQparameterStatus(const PGconn *conn, const char *paramName);
       <para>
        Parameters reported as of the current release include:
        <simplelist type="vert" columns="2">
+        <member><varname>agversion</varname></member>
         <member><varname>application_name</varname></member>
         <member><varname>client_encoding</varname></member>
         <member><varname>DateStyle</varname></member>
         <member><varname>default_transaction_read_only</varname></member>
+        <member><varname>graph_path</varname></member>
         <member><varname>in_hot_standby</varname></member>
         <member><varname>integer_datetimes</varname></member>
         <member><varname>IntervalStyle</varname></member>

--- a/doc/src/sgml/protocol.sgml
+++ b/doc/src/sgml/protocol.sgml
@@ -1403,10 +1403,12 @@ SELCT 1/0;<!-- this typo is intentional -->
     At present there is a hard-wired set of parameters for which
     ParameterStatus will be generated.  They are:
     <simplelist type="vert" columns="2">
+     <member><varname>agversion</varname></member>
      <member><varname>application_name</varname></member>
      <member><varname>client_encoding</varname></member>
      <member><varname>DateStyle</varname></member>
      <member><varname>default_transaction_read_only</varname></member>
+     <member><varname>graph_path</varname></member>
      <member><varname>in_hot_standby</varname></member>
      <member><varname>integer_datetimes</varname></member>
      <member><varname>IntervalStyle</varname></member>

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -5124,7 +5124,7 @@ struct config_string ConfigureNamesString[] =
 		{"graph_path", PGC_USERSET, CLIENT_CONN_STATEMENT,
 			gettext_noop("Sets the graph search path for all names."),
 			NULL,
-			GUC_IS_NAME
+			GUC_IS_NAME | GUC_REPORT
 		},
 		&graph_path,
 		"",


### PR DESCRIPTION
A client that reads a node, relationship or path in its composite form sees a label id, not a label name, and label ids start over in every graph: the first label a user creates is 3 in each of them.  So a client that names labels has to know which graph the session reads, and until now it could only find out by asking, or by watching the statements it sends for SET, RESET, set_config, RESET ALL and DISCARD ALL.  A change made inside a function body, one made by a connection pool between the client and the server, or one undone by a rollback never reached it, and a value of another graph was named with the wrong label, with no error on either side.

graph_path is marked GUC_REPORT, the way search_path is since PostgreSQL 18 for the same reason and the way agversion already is here.  The client receives the value once at connection start and a ParameterStatus message after any query during which it changed, at most one per query.  A client that ignores the message is where it was before.  The lists of reported parameters in the protocol and libpq documentation gain graph_path, and agversion, which they had never listed.