### PR TITLE
fix: let ALTER TABLE drop a label's constraint

### DIFF
--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -27,6 +27,7 @@
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_collation.h"
+#include "catalog/pg_constraint.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/toasting.h"
 #include "commands/event_trigger.h"
@@ -1032,6 +1033,8 @@ CheckLabelSqlReshape(Oid relid, bool recurse, List *cmds)
 		const char *hint;
 		const char *label_ddl_hint =
 			"Use ALTER VLABEL or ALTER ELABEL instead, which keeps the graph catalog in step.";
+		const char *not_null_hint =
+			"The columns every vertex or edge is made of are relied on to be there.";
 
 		switch (cmd->subtype)
 		{
@@ -1057,12 +1060,23 @@ CheckLabelSqlReshape(Oid relid, bool recurse, List *cmds)
 				break;
 			case AT_DropNotNull:
 				what = "drop a not-null constraint of";
-				hint = "The columns every vertex or edge is made of are relied on to be there.";
+				hint = not_null_hint;
 				break;
 			case AT_DropConstraint:
-				what = "drop a constraint of";
-				hint = "Use DROP CONSTRAINT on the label instead.";
-				break;
+				{
+					Oid			conoid;
+
+					/* naming a not-null constraint drops what AT_DropNotNull drops */
+					conoid = get_relation_constraint_oid(relid, cmd->name,
+														 true);
+					if (!OidIsValid(conoid) ||
+						get_constraint_type(conoid) != CONSTRAINT_NOTNULL)
+						continue;
+
+					what = "drop a not-null constraint of";
+					hint = not_null_hint;
+					break;
+				}
 			case AT_AddInherit:
 				what = "add a parent label to";
 				hint = "A label's parents are fixed when it is created.";

--- a/src/bin/pg_dump/meson.build
+++ b/src/bin/pg_dump/meson.build
@@ -106,6 +106,7 @@ tests += {
       't/010_dump_connstr.pl',
       't/011_promoted_columns.pl',
       't/012_label_constraints.pl',
+      't/013_clean_restore.pl',
     ],
   },
 }

--- a/src/bin/pg_dump/t/013_clean_restore.pl
+++ b/src/bin/pg_dump/t/013_clean_restore.pl
@@ -1,0 +1,145 @@
+# Copyright (c) 2026, PostgreSQL Global Development Group
+
+# Verify that a database holding a graph can be restored over itself with
+# --clean.
+#
+# A label's constraints are dropped with ALTER TABLE ... DROP CONSTRAINT and its
+# property indexes with DROP INDEX.  Every label carries a primary key, so a
+# graph with no constraint of its own is restored this way too.
+#
+# pg_restore with and without --if-exists, and the plain script through psql.
+# All run strict, so a refused statement fails the test.
+
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+$node->init;
+$node->start;
+
+my $graph = q{
+	CREATE GRAPH g;
+	SET graph_path = g;
+	CREATE VLABEL person;
+	CREATE CONSTRAINT person_ssn_uq ON person ASSERT ssn IS UNIQUE;
+	CREATE PROPERTY INDEX ON person (name);
+	-- carries only what every label carries
+	CREATE VLABEL bare;
+	-- an edge label carries a constraint the same way a vertex label does
+	CREATE ELABEL knows;
+	CREATE CONSTRAINT knows_tag_uq ON knows ASSERT tag IS UNIQUE;
+	CREATE PROPERTY INDEX knows_since_idx ON knows (since);
+	CREATE (:person {name:'a', ssn:'1'}), (:person {name:'b', ssn:'2'});
+	CREATE (:bare {k:1});
+	MATCH (x:person {ssn:'1'}), (y:person {ssn:'2'})
+	  CREATE (x)-[:knows {since:2020, tag:'t1'}]->(y);
+};
+
+$node->safe_psql('postgres', 'CREATE DATABASE clsrc');
+$node->safe_psql('clsrc', $graph);
+
+my $counts = q{SELECT (SELECT count(*) FROM g.person) || ' '
+                   || (SELECT count(*) FROM g.bare)   || ' '
+                   || (SELECT count(*) FROM g.knows)};
+
+my $constraints = q{
+	SELECT string_agg(t.relname || ':' || c.conname, ' '
+	                  ORDER BY (t.relname || ':' || c.conname) COLLATE "C")
+	  FROM pg_constraint c
+	  JOIN pg_class t ON t.oid = c.conrelid
+	  JOIN pg_namespace n ON n.oid = t.relnamespace
+	 WHERE n.nspname = 'g' AND c.contype <> 'n'};
+
+my $indexes = q{
+	SELECT string_agg(c.relname, ' ' ORDER BY c.relname COLLATE "C")
+	  FROM pg_class c
+	  JOIN pg_namespace n ON n.oid = c.relnamespace
+	 WHERE n.nspname = 'g' AND c.relkind = 'i'};
+
+my $want_counts = $node->safe_psql('clsrc', $counts);
+my $want_indexes = $node->safe_psql('clsrc', $indexes);
+my $want_constraints = $node->safe_psql('clsrc', $constraints);
+is($want_counts, '2 1 1', 'the source graph holds the rows the test expects');
+is( $want_constraints,
+	'ag_vertex:ag_vertex_pkey bare:bare_pkey knows:knows_tag_uq '
+	  . 'person:person_pkey person:person_ssn_uq',
+	'and the constraints the test expects, the primary keys included');
+is( $want_indexes,
+	'ag_edge_end_idx ag_edge_id_idx ag_edge_start_idx ag_vertex_pkey '
+	  . 'bare_pkey knows_end_idx knows_id_idx knows_since_idx '
+	  . 'knows_start_idx knows_tag_uq person_name_idx person_pkey '
+	  . 'person_ssn_uq',
+	'and the indexes, the property indexes among them');
+
+my $dumpfile = "${PostgreSQL::Test::Utils::tmp_check}/clean_restore.dump";
+my $scriptfile = "${PostgreSQL::Test::Utils::tmp_check}/clean_restore.sql";
+$node->command_ok(
+	[ 'pg_dump', '-Fc', '-f', $dumpfile, '-d', $node->connstr('clsrc') ],
+	'pg_dump of a graph succeeds');
+$node->command_ok(
+	[ 'pg_dump', '--clean', '-f', $scriptfile, '-d', $node->connstr('clsrc') ],
+	'pg_dump --clean of a graph succeeds');
+
+# Each target already holds the same graph, so every drop has something to drop.
+my $target = 0;
+sub fresh_target
+{
+	my $db = 'cldst' . $target++;
+	$node->safe_psql('postgres', "CREATE DATABASE $db");
+	$node->safe_psql($db, $graph);
+	return $db;
+}
+
+my $db = fresh_target();
+$node->command_ok(
+	[
+		'pg_restore', '--clean', '--exit-on-error',
+		'-d', $node->connstr($db), $dumpfile
+	],
+	'pg_restore --clean over the same graph succeeds');
+is($node->safe_psql($db, $counts), $want_counts,
+	'every label has its rows after the clean restore');
+is($node->safe_psql($db, $constraints), $want_constraints,
+	'every constraint is back after the clean restore');
+is($node->safe_psql($db, $indexes), $want_indexes,
+	'and every index, the property indexes included');
+
+# --if-exists rewrites each drop, which is a second spelling to accept.
+$db = fresh_target();
+$node->command_ok(
+	[
+		'pg_restore', '--clean', '--if-exists', '--exit-on-error',
+		'-d', $node->connstr($db), $dumpfile
+	],
+	'pg_restore --clean --if-exists over the same graph succeeds');
+is($node->safe_psql($db, $counts), $want_counts,
+	'every label has its rows after the --if-exists clean restore');
+is($node->safe_psql($db, $indexes), $want_indexes,
+	'and every index after it too');
+
+$db = fresh_target();
+$node->command_ok(
+	[
+		'psql', '-X', '-v', 'ON_ERROR_STOP=1', '-f', $scriptfile,
+		'-d', $node->connstr($db)
+	],
+	'a --clean script restores over the same graph without error');
+is($node->safe_psql($db, $counts), $want_counts,
+	'every label has its rows after the script restore');
+is($node->safe_psql($db, $constraints), $want_constraints,
+	'every constraint is back after the script restore');
+is($node->safe_psql($db, $indexes), $want_indexes,
+	'and every index is back after the script restore');
+
+my ($ret, $stdout, $stderr) = $node->psql($db,
+	"SET graph_path = g; CREATE (:person {name:'c', ssn:'1'});");
+isnt($ret, 0, 'the restored unique constraint still refuses a duplicate');
+like($stderr, qr/violates exclusion constraint/,
+	'and it refuses it as a constraint violation');
+
+$node->stop;
+done_testing();

--- a/src/test/regress/expected/cypher_typed_column.out
+++ b/src/test/regress/expected/cypher_typed_column.out
@@ -5689,14 +5689,24 @@ HINT:  The columns every vertex or edge is made of are relied on to be there.
 -- 22a. The label's own DDL does these things and is unaffected.
 ALTER VLABEL gate ADD COLUMN nm text GENERATED;
 ALTER VLABEL gate DROP COLUMN nm;
--- 22a2. A constraint on a label is dropped by the graph's own DDL, which is
---       rewritten into an ALTER TABLE -- so what the graph itself issues has to
---       keep working while the same thing typed directly is refused.
+-- 22a2. A constraint goes on a label with ALTER TABLE and comes off the same
+--       way, the primary key included.  The graph's own DDL drops one too.
 CREATE CONSTRAINT gate_uk ON gate ASSERT age IS UNIQUE;
 ALTER TABLE tc.gate DROP CONSTRAINT gate_uk;
-ERROR:  cannot drop a constraint of graph label "gate" with ALTER TABLE
-HINT:  Use DROP CONSTRAINT on the label instead.
+CREATE CONSTRAINT gate_uk ON gate ASSERT age IS UNIQUE;
 DROP CONSTRAINT gate_uk ON gate;
+ALTER TABLE ONLY tc.gate DROP CONSTRAINT gate_pkey;
+ALTER TABLE ONLY tc.gate ADD CONSTRAINT gate_pkey PRIMARY KEY (id);
+-- 22a3. Naming a not-null constraint is refused the way DROP NOT NULL is, and
+--       IF EXISTS does not get past it.
+ALTER TABLE tc.gate DROP CONSTRAINT gate_properties_not_null;
+ERROR:  cannot drop a not-null constraint of graph label "gate" with ALTER TABLE
+HINT:  The columns every vertex or edge is made of are relied on to be there.
+ALTER TABLE tc.gate DROP CONSTRAINT IF EXISTS gate_id_not_null;
+ERROR:  cannot drop a not-null constraint of graph label "gate" with ALTER TABLE
+HINT:  The columns every vertex or edge is made of are relied on to be there.
+ALTER TABLE tc.gate DROP CONSTRAINT IF EXISTS gate_no_such_constraint;
+NOTICE:  constraint "gate_no_such_constraint" of relation "gate" does not exist, skipping
 -- 22b. An ALTER TABLE that reshapes nothing is still allowed, including the ones
 --      a dump emits.
 ALTER TABLE tc.gate ALTER COLUMN properties SET DEFAULT jsonb_build_object();
@@ -5897,14 +5907,8 @@ ALTER TABLE tc.gate DISABLE TRIGGER ALL;
 ALTER TABLE tc.gate ENABLE TRIGGER ALL;
 ALTER TABLE tc.gate REPLICA IDENTITY FULL;
 ALTER TABLE tc.gate REPLICA IDENTITY DEFAULT;
--- dropping that constraint, though, is refused -- and the graph's own DDL is how
--- it is done, which reaches ALTER TABLE as a subcommand and so is not judged
+-- and dropping it again puts the label back as it was
 ALTER TABLE tc.gate DROP CONSTRAINT gate_chk;
-ERROR:  cannot drop a constraint of graph label "gate" with ALTER TABLE
-HINT:  Use DROP CONSTRAINT on the label instead.
-SET enable_graph_ddl = on;
-ALTER TABLE tc.gate DROP CONSTRAINT gate_chk;
-RESET enable_graph_ddl;
 -- 22j. A table that is not a label is not affected by any of them.
 CREATE TABLE tc_ordinary (a int GENERATED ALWAYS AS (1) STORED, b int NOT NULL);
 CREATE TABLE tc_ordinary_kid () INHERITS (tc_ordinary);

--- a/src/test/regress/sql/cypher_typed_column.sql
+++ b/src/test/regress/sql/cypher_typed_column.sql
@@ -2257,12 +2257,20 @@ ALTER TABLE tc.gate ALTER COLUMN properties DROP NOT NULL;
 ALTER VLABEL gate ADD COLUMN nm text GENERATED;
 ALTER VLABEL gate DROP COLUMN nm;
 
--- 22a2. A constraint on a label is dropped by the graph's own DDL, which is
---       rewritten into an ALTER TABLE -- so what the graph itself issues has to
---       keep working while the same thing typed directly is refused.
+-- 22a2. A constraint goes on a label with ALTER TABLE and comes off the same
+--       way, the primary key included.  The graph's own DDL drops one too.
 CREATE CONSTRAINT gate_uk ON gate ASSERT age IS UNIQUE;
 ALTER TABLE tc.gate DROP CONSTRAINT gate_uk;
+CREATE CONSTRAINT gate_uk ON gate ASSERT age IS UNIQUE;
 DROP CONSTRAINT gate_uk ON gate;
+ALTER TABLE ONLY tc.gate DROP CONSTRAINT gate_pkey;
+ALTER TABLE ONLY tc.gate ADD CONSTRAINT gate_pkey PRIMARY KEY (id);
+
+-- 22a3. Naming a not-null constraint is refused the way DROP NOT NULL is, and
+--       IF EXISTS does not get past it.
+ALTER TABLE tc.gate DROP CONSTRAINT gate_properties_not_null;
+ALTER TABLE tc.gate DROP CONSTRAINT IF EXISTS gate_id_not_null;
+ALTER TABLE tc.gate DROP CONSTRAINT IF EXISTS gate_no_such_constraint;
 
 -- 22b. An ALTER TABLE that reshapes nothing is still allowed, including the ones
 --      a dump emits.
@@ -2407,12 +2415,8 @@ ALTER TABLE tc.gate DISABLE TRIGGER ALL;
 ALTER TABLE tc.gate ENABLE TRIGGER ALL;
 ALTER TABLE tc.gate REPLICA IDENTITY FULL;
 ALTER TABLE tc.gate REPLICA IDENTITY DEFAULT;
--- dropping that constraint, though, is refused -- and the graph's own DDL is how
--- it is done, which reaches ALTER TABLE as a subcommand and so is not judged
+-- and dropping it again puts the label back as it was
 ALTER TABLE tc.gate DROP CONSTRAINT gate_chk;
-SET enable_graph_ddl = on;
-ALTER TABLE tc.gate DROP CONSTRAINT gate_chk;
-RESET enable_graph_ddl;
 
 -- 22j. A table that is not a label is not affected by any of them.
 CREATE TABLE tc_ordinary (a int GENERATED ALWAYS AS (1) STORED, b int NOT NULL);


### PR DESCRIPTION
A constraint is put on a label with ALTER TABLE ADD CONSTRAINT, which is how a dump restores a label's primary key.  Taking one off with ALTER TABLE DROP CONSTRAINT was refused.

A dump that drops each object before creating it emits that statement, so restoring a graph over a database that already held it failed.  pg_restore --clean reported an error for every constraint of every label and returned 1. With --exit-on-error, or a --clean script read with ON_ERROR_STOP, it stopped at the first one and restored nothing.  Every label has a primary key, so a graph carrying no constraint of its own failed the same way.

The refusal held back almost nothing: the graph's own DROP CONSTRAINT, which it pointed at, drops a label's primary key just as readily.  What it did hold back is a not-null constraint named as a constraint, which drops what ALTER COLUMN DROP NOT NULL drops.  A label's constraint is now dropped with ALTER TABLE, and a not-null constraint is refused whichever of the two names it, with the message the column spelling already gives.