### PR TITLE
fix: dump both names of a label's named not-null constraint

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -20741,10 +20741,14 @@ dumpLabelSchema(Archive *fout, const TableInfo *tblinfo)
 			appendPQExpBuffer(q, "ALTER TABLE ONLY %s ALTER COLUMN %s SET NOT NULL;\n",
 							  qualrelname, fmtId(tblinfo->attnames[j]));
 		else
-			appendPQExpBuffer(q, "ALTER TABLE ONLY %s ADD CONSTRAINT %s NOT NULL %s;\n",
+		{
+			/* fmtId returns one shared buffer, so the two names take separate calls */
+			appendPQExpBuffer(q, "ALTER TABLE ONLY %s ADD CONSTRAINT %s ",
 							  qualrelname,
-							  fmtId(tblinfo->notnull_constrs[j]),
+							  fmtId(tblinfo->notnull_constrs[j]));
+			appendPQExpBuffer(q, "NOT NULL %s;\n",
 							  fmtId(tblinfo->attnames[j]));
+		}
 	}
 
 	/*

--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -3718,6 +3718,30 @@ my %tests = (
 		like => { binary_upgrade => 1, },
 	},
 
+	# Both names are quoted, and each takes its own call: fmtId hands back one
+	# shared buffer, so asking for two at once loses one of them.
+	'ADD CONSTRAINT ... NOT NULL on a promoted column' => {
+		create_order => 142,
+		create_sql => 'SET graph_path = dump_test_graph;
+					   CREATE VLABEL dtg_nn (since text GENERATED);
+					   ALTER TABLE dump_test_graph.dtg_nn
+					       ADD CONSTRAINT dtg_nn_since_nn NOT NULL since;',
+		regexp =>
+		  qr/^\QALTER TABLE ONLY dump_test_graph.dtg_nn ADD CONSTRAINT dtg_nn_since_nn NOT NULL since;\E$/m,
+		like => { %full_runs, section_pre_data => 1, },
+	},
+
+	'ADD CONSTRAINT ... NOT NULL where both names need quoting' => {
+		create_order => 143,
+		create_sql => 'SET graph_path = dump_test_graph;
+					   CREATE VLABEL dtg_nnq ("Since When" text GENERATED);
+					   ALTER TABLE dump_test_graph.dtg_nnq
+					       ADD CONSTRAINT "Dtg NN" NOT NULL "Since When";',
+		regexp =>
+		  qr/^\QALTER TABLE ONLY dump_test_graph.dtg_nnq ADD CONSTRAINT "Dtg NN" NOT NULL "Since When";\E$/m,
+		like => { %full_runs, section_pre_data => 1, },
+	},
+
 	'CREATE PROPERTY INDEX' => {
 		create_order => 139,
 		create_sql => 'SET graph_path = dump_test_graph;

--- a/src/bin/pg_dump/t/012_label_constraints.pl
+++ b/src/bin/pg_dump/t/012_label_constraints.pl
@@ -60,6 +60,8 @@ my $graph = q{
 	-- one over a promoted column, which arrives with the label rather than after it
 	CREATE VLABEL typed (age int GENERATED);
 	ALTER TABLE g.typed ADD CONSTRAINT typed_age_chk CHECK (age IS NULL OR age >= 0);
+	-- a named NOT NULL on that column names two identifiers in one statement
+	ALTER TABLE g.typed ADD CONSTRAINT typed_age_nn NOT NULL age;
 	-- one left NOT VALID, which reaches the dump by another path
 	CREATE VLABEL nv;
 	ALTER TABLE g.nv ADD CONSTRAINT nv_chk CHECK ((properties->>'k')::int > 0) NOT VALID;


### PR DESCRIPTION
The statement that dumps a named not-null constraint on a promoted column asked fmtId for the constraint's name and for the column's name in one call.  fmtId hands back a single shared buffer, so whichever name it formatted last was the one both slots got, and C does not say which that is: gcc wrote the constraint name twice, clang the column name twice.  It is the only place in the tree that asks for two of those at once.

The restore then named a column that does not exist.  psql reported the error and carried on with an exit status of 0, leaving the constraint behind, and pg_restore --exit-on-error stopped, which is the condition an upgrade runs under.

The statement is built by two calls now, so only one name is in that buffer at a time.  Both are still quoted, so a constraint or a column whose name is not folded lower case survives the round trip too.