### PR TITLE
fix: dump a label's exclusion constraint as itself unless Cypher can …

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7712,9 +7712,36 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 				i_indstatvals;
 
 	int			i_ispropidx;
+	int			i_isassertunique;
 	char		sql_is_prop_idx[] = "ag_label.oid IS NOT NULL "
 		"AND i.indisexclusion = false "
 		"AND i.indexprs IS NOT NULL";
+
+	/*
+	 * A label's unique constraint is an exclusion constraint of one shape:
+	 * ASSERT expr IS UNIQUE builds one btree column over a property, compared
+	 * with =, and can say nothing else.  Any other exclusion constraint on a
+	 * label has no Cypher spelling, so it is dumped as the SQL that made it.
+	 * The test is made here rather than by the server, because pg_upgrade
+	 * dumps the old cluster with the new pg_dump.
+	 */
+	char		sql_is_assert_unique[] = "ag_label.oid IS NOT NULL "
+		"AND c.contype = 'x' "
+		"AND i.indnatts = 1 "
+		"AND i.indexprs IS NOT NULL "
+		"AND i.indpred IS NULL "
+		"AND i.indcollation[0] = 0 "
+		"AND i.indoption[0] = 0 "
+		"AND i.indclass[0] IN (SELECT oid FROM pg_catalog.pg_opclass "
+		"                       WHERE opcdefault) "
+		"AND t.relam = (SELECT oid FROM pg_catalog.pg_am "
+		"                WHERE amname = 'btree') "
+		"AND t.reloptions IS NULL "
+		"AND NOT c.condeferrable "
+		"AND c.convalidated "
+		"AND c.conexclop <@ (SELECT pg_catalog.array_agg(oid) "
+		"                      FROM pg_catalog.pg_operator "
+		"                     WHERE oprname = '=')";
 
 	/*
 	 * We want to perform just one query against pg_index.  However, we
@@ -7764,9 +7791,10 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 					  "c.condeferrable, c.condeferred, "
 					  "c.tableoid AS contableoid, "
 					  "c.oid AS conoid, "
-					  "(CASE WHEN ag_label.oid IS NOT NULL AND c.contype = 'x' THEN ag_get_graphconstraintdef(c.oid)"
+					  "(CASE WHEN %s THEN ag_get_graphconstraintdef(c.oid)"
 					  "		 ELSE pg_catalog.pg_get_constraintdef(c.oid, false)"
 					  "END) AS condef, "
+					  "(%s) AS isassertunique, "
 					  "CASE WHEN i.indexprs IS NOT NULL THEN "
 					  "(SELECT pg_catalog.array_agg(attname ORDER BY attnum)"
 					  "  FROM pg_catalog.pg_attribute "
@@ -7774,7 +7802,8 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 					  "ELSE NULL END AS indattnames, "
 					  "(SELECT spcname FROM pg_catalog.pg_tablespace s WHERE s.oid = t.reltablespace) AS tablespace, "
 					  "t.reloptions AS indreloptions, ",
-					  sql_is_prop_idx);
+					  sql_is_prop_idx, sql_is_assert_unique,
+					  sql_is_assert_unique);
 
 
 	if (fout->remoteVersion >= 90400)
@@ -7902,6 +7931,7 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 	i_indstatcols = PQfnumber(res, "indstatcols");
 	i_indstatvals = PQfnumber(res, "indstatvals");
 	i_ispropidx = PQfnumber(res, "ispropidx");
+	i_isassertunique = PQfnumber(res, "isassertunique");
 
 	indxinfo = (IndxInfo *) pg_malloc(ntups * sizeof(IndxInfo));
 
@@ -7974,6 +8004,8 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 				indxinfo[j].ispropidx = false;
 			else
 				indxinfo[j].ispropidx = *(PQgetvalue(res, j, i_ispropidx)) == 't';
+			indxinfo[j].isassertunique =
+				*(PQgetvalue(res, j, i_isassertunique)) == 't';
 
 			indxinfo[j].indkeys = (Oid *) pg_malloc(indxinfo[j].indnattrs * sizeof(Oid));
 			parseOidArray(PQgetvalue(res, j, i_indkey),
@@ -18354,8 +18386,7 @@ dumpConstraint(Archive *fout, const ConstraintInfo *coninfo)
 		 * Also, it would be better to implement a special Cypher syntax so
 		 * that it can be used in ALTER TABLE.
 		 */
-		if ((tbinfo->ag_labkind > 0 && coninfo->contype == 'x') ||
-			indxinfo->ispropidx)
+		if (indxinfo->isassertunique || indxinfo->ispropidx)
 		{
 			setGraphPath(q, tbinfo->dobj.namespace);
 

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -435,6 +435,7 @@ typedef struct _indxInfo
 	/* if there is an associated constraint object, its dumpId: */
 	DumpId		indexconstraint;
 	bool		ispropidx;		/* Is it cypher property index? */
+	bool		isassertunique; /* Is it what ASSERT ... IS UNIQUE makes? */
 } IndxInfo;
 
 typedef struct _indexAttachInfo

--- a/src/bin/pg_dump/t/002_pg_dump.pl
+++ b/src/bin/pg_dump/t/002_pg_dump.pl
@@ -3720,6 +3720,56 @@ my %tests = (
 
 	# Both names are quoted, and each takes its own call: fmtId hands back one
 	# shared buffer, so asking for two at once loses one of them.
+	# Only the one shape ASSERT expr IS UNIQUE builds has a Cypher spelling.
+	# Any other exclusion constraint on a label is dumped as the SQL that made
+	# it, so it restores as the constraint it is.
+	'ADD CONSTRAINT ... EXCLUDE with an operator other than =' => {
+		create_order => 144,
+		create_sql => 'SET graph_path = dump_test_graph;
+					   CREATE VLABEL dtg_ov;
+					   ALTER TABLE dump_test_graph.dtg_ov ADD CONSTRAINT dtg_ov_ex
+					       EXCLUDE USING gist ((int4range((properties->>\'a\')::int,
+					                                      (properties->>\'b\')::int)) WITH &&);',
+		regexp => qr/^
+			\QALTER TABLE ONLY dump_test_graph.dtg_ov\E\n
+			\s+\QADD CONSTRAINT dtg_ov_ex EXCLUDE USING gist (int4range(((properties ->> 'a'::text))::integer, ((properties ->> 'b'::text))::integer) WITH &&);\E
+			/xm,
+		like => { %full_runs, section_post_data => 1, },
+	},
+
+	'CREATE CONSTRAINT is not used for an exclusion Cypher cannot spell' => {
+		regexp => qr/^\QCREATE CONSTRAINT dtg_ov_ex ON dtg_ov\E/m,
+		like => {},
+	},
+
+	'ADD CONSTRAINT ... EXCLUDE that is deferrable' => {
+		create_order => 145,
+		create_sql => 'SET graph_path = dump_test_graph;
+					   CREATE VLABEL dtg_defr;
+					   ALTER TABLE dump_test_graph.dtg_defr ADD CONSTRAINT dtg_defr_ex
+					       EXCLUDE USING btree (((properties->>\'k\')) WITH =) DEFERRABLE;',
+		regexp => qr/^
+			\QALTER TABLE ONLY dump_test_graph.dtg_defr\E\n
+			\s+\QADD CONSTRAINT dtg_defr_ex EXCLUDE USING btree (((properties ->> 'k'::text)) WITH =) DEFERRABLE;\E
+			/xm,
+		like => { %full_runs, section_post_data => 1, },
+	},
+
+	# on a column rather than a property: Cypher would read the name as a
+	# property and build a different constraint
+	'ADD CONSTRAINT ... EXCLUDE on a label column' => {
+		create_order => 146,
+		create_sql => 'SET graph_path = dump_test_graph;
+					   CREATE VLABEL dtg_idcol;
+					   ALTER TABLE dump_test_graph.dtg_idcol ADD CONSTRAINT dtg_idcol_ex
+					       EXCLUDE USING btree (id WITH =);',
+		regexp => qr/^
+			\QALTER TABLE ONLY dump_test_graph.dtg_idcol\E\n
+			\s+\QADD CONSTRAINT dtg_idcol_ex EXCLUDE USING btree (id WITH =);\E
+			/xm,
+		like => { %full_runs, section_post_data => 1, },
+	},
+
 	'ADD CONSTRAINT ... NOT NULL on a promoted column' => {
 		create_order => 142,
 		create_sql => 'SET graph_path = dump_test_graph;

--- a/src/bin/pg_dump/t/012_label_constraints.pl
+++ b/src/bin/pg_dump/t/012_label_constraints.pl
@@ -62,6 +62,10 @@ my $graph = q{
 	ALTER TABLE g.typed ADD CONSTRAINT typed_age_chk CHECK (age IS NULL OR age >= 0);
 	-- a named NOT NULL on that column names two identifiers in one statement
 	ALTER TABLE g.typed ADD CONSTRAINT typed_age_nn NOT NULL age;
+	-- an exclusion constraint Cypher cannot spell, over a column rather than a
+	-- property: written as Cypher it would name a property and mean something else
+	CREATE VLABEL notcypher;
+	ALTER TABLE g.notcypher ADD CONSTRAINT notcypher_id_ex EXCLUDE USING btree (id WITH =);
 	-- one left NOT VALID, which reaches the dump by another path
 	CREATE VLABEL nv;
 	ALTER TABLE g.nv ADD CONSTRAINT nv_chk CHECK ((properties->>'k')::int > 0) NOT VALID;
@@ -86,6 +90,7 @@ my $unique_query = q{
 	 WHERE c.contype = 'x' AND n.nspname = 'g'};
 
 my $want_unique = 'Mixed|Mixed_uq|Mixed_uq erel|erel_uq|erel_uq '
+  . 'notcypher|notcypher_id_ex|notcypher_id_ex '
   . 'order|ord_uq|ord_uq person|person_ssn_uq|person_ssn_uq '
   . 'two|two_unique_constraint|two_unique_constraint '
   . 'two|two_unique_constraint1|two_unique_constraint1';
@@ -101,10 +106,25 @@ my $check_query = q{
 	  JOIN pg_namespace n ON n.oid = t.relnamespace
 	 WHERE n.nspname = 'g' AND c.contype = 'c'};
 
+# What each exclusion constraint is, as opposed to merely what it is called: one
+# written as Cypher when it cannot be would restore as a different constraint
+# under the same name.
+my $exclusion_defs = q{
+	SELECT string_agg(t.relname || ' ' || pg_catalog.pg_get_constraintdef(c.oid), ' | '
+	                  ORDER BY (t.relname || c.conname) COLLATE "C")
+	  FROM pg_constraint c
+	  JOIN pg_class t ON t.oid = c.conrelid
+	  JOIN pg_namespace n ON n.oid = t.relnamespace
+	 WHERE n.nspname = 'g' AND c.contype = 'x'};
+
 my $want_check = 'acct:acct_age_chk:valid:local cyp:cyp_named:valid:local '
   . 'cyp:cyp_pos:valid:local erel:erel_chk:valid:local '
   . 'kid:par_chk:valid:inherited nv:nv_chk:notvalid:local '
   . 'par:par_chk:valid:local typed:typed_age_chk:valid:local';
+
+my $want_defs = $node->safe_psql('consrc', $exclusion_defs);
+like($want_defs, qr/\Qnotcypher EXCLUDE USING btree (id WITH =)\E/,
+	'the source graph holds an exclusion constraint Cypher cannot spell');
 
 is($node->safe_psql('consrc', $unique_query), $want_unique,
 	'the source graph holds the unique constraints the test expects');
@@ -157,6 +177,8 @@ is($node->safe_psql('condst', $unique_query), $want_unique,
 	'every unique constraint and its index come back under the same name');
 is($node->safe_psql('condst', $check_query), $want_check,
 	'and every CHECK, with its validity and inheritance');
+is($node->safe_psql('condst', $exclusion_defs), $want_defs,
+	'and every exclusion constraint is the same constraint, not just the same name');
 
 # Re-dumping has to reproduce the same dump, so this runs before anything
 # writes to the restored database: a refused write still consumes an id.
@@ -201,6 +223,8 @@ is($dst->safe_psql('conbu', $unique_query), $want_unique,
 	'the binary-upgrade restore keeps every constraint and index name');
 is($dst->safe_psql('conbu', $check_query), $want_check,
 	'and every CHECK');
+is($dst->safe_psql('conbu', $exclusion_defs), $want_defs,
+	'and every exclusion constraint is unchanged');
 constraints_enforced($dst, 'conbu', 'binary upgrade');
 $dst->stop;
 

--- a/src/bin/psql/cypher_describe.c
+++ b/src/bin/psql/cypher_describe.c
@@ -426,13 +426,39 @@ describeOneLabelDetails(const char *graphname, const char *labelname)
 		PGresult   *result = NULL;
 		int			tuples = 0;
 
+		/*
+		 * Only an exclusion constraint of the one shape ASSERT expr IS UNIQUE
+		 * builds -- one btree column over a property, compared with = -- has a
+		 * Cypher spelling.  Any other one is shown as the SQL that made it.
+		 * pg_dump decides the same thing the same way, in getIndexes().
+		 */
 		printfPQExpBuffer(&buf,
-						  "SELECT r.conname, "
-						  "pg_catalog.ag_get_graphconstraintdef(r.oid)\n"
-						  "FROM pg_catalog.pg_constraint r, "
-						  "pg_catalog.ag_label l, pg_catalog.ag_graph g\n"
-						  "WHERE r.conrelid = l.relid AND l.graphid = g.oid AND "
-						  "l.labname = '%s' AND g.graphname = '%s' AND "
+						  "SELECT r.conname,\n"
+						  "  CASE WHEN r.contype = 'c'\n"
+						  "         OR (i.indnatts = 1\n"
+						  "             AND i.indexprs IS NOT NULL\n"
+						  "             AND i.indpred IS NULL\n"
+						  "             AND i.indcollation[0] = 0\n"
+						  "             AND i.indoption[0] = 0\n"
+						  "             AND i.indclass[0] IN (SELECT oid FROM pg_catalog.pg_opclass\n"
+						  "                                    WHERE opcdefault)\n"
+						  "             AND t.relam = (SELECT oid FROM pg_catalog.pg_am\n"
+						  "                             WHERE amname = 'btree')\n"
+						  "             AND t.reloptions IS NULL\n"
+						  "             AND NOT r.condeferrable\n"
+						  "             AND r.convalidated\n"
+						  "             AND r.conexclop <@ (SELECT pg_catalog.array_agg(oid)\n"
+						  "                                   FROM pg_catalog.pg_operator\n"
+						  "                                  WHERE oprname = '='))\n"
+						  "       THEN pg_catalog.ag_get_graphconstraintdef(r.oid)\n"
+						  "       ELSE pg_catalog.pg_get_constraintdef(r.oid)\n"
+						  "  END\n"
+						  "FROM pg_catalog.pg_constraint r\n"
+						  "  JOIN pg_catalog.ag_label l ON r.conrelid = l.relid\n"
+						  "  JOIN pg_catalog.ag_graph g ON l.graphid = g.oid\n"
+						  "  LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = r.conindid\n"
+						  "  LEFT JOIN pg_catalog.pg_class t ON t.oid = r.conindid\n"
+						  "WHERE l.labname = '%s' AND g.graphname = '%s' AND "
 						  "r.contype IN ('c','x')\n"
 						  "ORDER BY 1;",
 						  labelname, graphname);


### PR DESCRIPTION
…spell it

A label's unique constraint is an exclusion constraint, so the dump took every exclusion constraint on a label for one and asked for its Cypher spelling.  Only one shape has a Cypher spelling: ASSERT expr IS UNIQUE builds a single btree column over a property, compared with =, and can say nothing else.

Everything else was mishandled, mostly not loudly.  An operator other than = made the deparser raise an internal error, which took the whole dump with it, blocked an upgrade, and made \dGv fail as well.  The rest were written as Cypher that does not parse.  A deferrable one, a partial one, one over more than one column, one with a collation: the restore reported a syntax error, carried on without the constraint, and psql still exited 0.  One shape was worse.  An exclusion over a label's own column was written as ASSERT (id) IS UNIQUE, and there id names the property, so the restore built a different constraint under the same name and reported nothing.

pg_dump and psql now ask, in SQL, whether the constraint is the one ASSERT builds, and use the Cypher form only then.  The question is asked by the client because pg_upgrade dumps the old cluster with the new pg_dump, so the server that still raises the error is the case that has to keep working.