### PR TITLE
fix: refuse a row whose id names another graph label

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1248,6 +1248,8 @@ InitResultRelInfo(ResultRelInfo *resultRelInfo,
 	resultRelInfo->type = T_ResultRelInfo;
 	resultRelInfo->ri_RangeTableIndex = resultRelationIndex;
 	resultRelInfo->ri_RelationDesc = resultRelationDesc;
+	resultRelInfo->ri_GraphLabid =
+		get_relid_labid(RelationGetRelid(resultRelationDesc));
 	resultRelInfo->ri_NumIndices = 0;
 	resultRelInfo->ri_IndexRelationDescs = NULL;
 	resultRelInfo->ri_IndexRelationInfo = NULL;
@@ -2006,6 +2008,35 @@ ExecConstraints(ResultRelInfo *resultRelInfo,
 										  notnull_virtual_attrs);
 		if (attnum != InvalidAttrNumber)
 			ReportNotNullViolationError(resultRelInfo, slot, estate, attnum);
+	}
+
+	/*
+	 * Verify that the id names the label that stores the row.
+	 *
+	 * A vertex or edge is named by the label it is stored in, and that name is
+	 * read back from the first part of its id.  Everything that stores a row
+	 * arrives here: a Cypher write, an INSERT, an UPDATE, COPY and a logical
+	 * replication apply.
+	 */
+	if (resultRelInfo->ri_GraphLabid != InvalidLabid)
+	{
+		Datum		iddat;
+		bool		isnull;
+
+		/* a label carries its id first */
+		iddat = slot_getattr(slot, 1, &isnull);
+		if (!isnull)
+		{
+			Graphid		id = DatumGetGraphid(iddat);
+
+			if (GraphidGetLabid(id) != resultRelInfo->ri_GraphLabid)
+				ereport(ERROR,
+						(errcode(ERRCODE_CHECK_VIOLATION),
+						 errmsg("id \"%hu.%lu\" does not belong to graph label \"%s\"",
+								GraphidGetLabid(id), GraphidGetLocid(id),
+								RelationGetRelationName(rel)),
+						 errdetail("The label a vertex or edge belongs to is read from its id, so it has to be the label that stores it.")));
+		}
 	}
 
 	/*

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -479,6 +479,9 @@ typedef struct ResultRelInfo
 	/* relation descriptor for result relation */
 	Relation	ri_RelationDesc;
 
+	/* label stored in that relation, InvalidLabid if it is not a label */
+	Labid		ri_GraphLabid;
+
 	/* # of indices existing on result relation */
 	int			ri_NumIndices;
 

--- a/src/test/regress/expected/cypher_element_identity.out
+++ b/src/test/regress/expected/cypher_element_identity.out
@@ -7,10 +7,9 @@
 -- comparing the identities instead: the same answer, reached without reading
 -- the property map, so the element itself need not be built at all.
 --
--- Exactness rests on what the comparison reads, not on an identity being
--- unique.  The same graphid can appear under two labels (a label's id column
--- has a default, not a constraint), and both spellings answer the same there
--- too -- covered below.
+-- Exactness rests on what the comparison reads.  Two labels cannot share a
+-- graphid: the first part of one names the label that stores the row, and a
+-- write whose id names another label is refused -- covered below.
 --
 -- Oracle for every result-returning query: the rows must equal what the
 -- explicitly id-spelled query returns.  EXPLAIN (costs off) asserts that the
@@ -274,29 +273,49 @@ LINE 1: MATCH (x:p), (y:p) WHERE x = id(y) RETURN count(*);
                                    ^
 HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 --
--- The identity need not be unique for either spelling to be right
+-- Two labels cannot share an identity
 --
--- Give a q vertex a p vertex's graphid.  Both spellings then match the pair,
--- because both ask the same question.
+-- The first part of a graphid is the label that stores the row, so giving a q
+-- vertex a p vertex's graphid is refused, and elements of two labels are never
+-- equal.
 --
 SET enable_graph_dml = on;
 INSERT INTO ei.q (id, properties)
   SELECT id, '{"n": "clone"}'::jsonb FROM ei.p ORDER BY id LIMIT 1;
+ERROR:  id "3.1" does not belong to graph label "q"
+DETAIL:  The label a vertex or edge belongs to is read from its id, so it has to be the label that stores it.
 RESET enable_graph_dml;
-MATCH (x:p), (y:q) WHERE x = y RETURN x.n, y.n;
-  n  |    n    
------+---------
- "a" | "clone"
+MATCH (x:p), (y:q) WHERE x = y RETURN count(*);
+ count 
+-------
+ 0
 (1 row)
 
-MATCH (x:p), (y:q) WHERE id(x) = id(y) RETURN x.n, y.n;
-  n  |    n    
------+---------
- "a" | "clone"
+MATCH (x:p), (y:q) WHERE id(x) = id(y) RETURN count(*);
+ count 
+-------
+ 0
 (1 row)
 
+-- COPY writes a row without going through parse analysis, and is refused just
+-- the same; 9999 is no label of this graph
+COPY ei.q (id, properties) FROM STDIN;
+ERROR:  id "9999.1" does not belong to graph label "q"
+DETAIL:  The label a vertex or edge belongs to is read from its id, so it has to be the label that stores it.
+CONTEXT:  COPY q, line 1: "9999.1	{"n": "copied"}"
+-- and so is moving a row that is already there onto another label's id
 SET enable_graph_dml = on;
-DELETE FROM ei.q WHERE properties->>'n' = 'clone';
+UPDATE ei.q SET id = graphid(9999, 1) WHERE properties->>'n' = 'z';
+ERROR:  id "9999.1" does not belong to graph label "q"
+DETAIL:  The label a vertex or edge belongs to is read from its id, so it has to be the label that stores it.
+-- an edge label is named by its id the same way
+UPDATE ei.k SET id = graphid(9999, 1);
+ERROR:  id "9999.1" does not belong to graph label "k"
+DETAIL:  The label a vertex or edge belongs to is read from its id, so it has to be the label that stores it.
+-- what the label's own default produces is accepted, so an ordinary SQL write
+-- of a graph element still works
+INSERT INTO ei.q (properties) VALUES ('{"n": "sql"}');
+DELETE FROM ei.q WHERE properties->>'n' = 'sql';
 RESET enable_graph_dml;
 --
 -- NULLIF yields its first operand, so that operand stays the element

--- a/src/test/regress/sql/cypher_element_identity.sql
+++ b/src/test/regress/sql/cypher_element_identity.sql
@@ -7,10 +7,9 @@
 -- comparing the identities instead: the same answer, reached without reading
 -- the property map, so the element itself need not be built at all.
 --
--- Exactness rests on what the comparison reads, not on an identity being
--- unique.  The same graphid can appear under two labels (a label's id column
--- has a default, not a constraint), and both spellings answer the same there
--- too -- covered below.
+-- Exactness rests on what the comparison reads.  Two labels cannot share a
+-- graphid: the first part of one names the label that stores the row, and a
+-- write whose id names another label is refused -- covered below.
 --
 -- Oracle for every result-returning query: the rows must equal what the
 -- explicitly id-spelled query returns.  EXPLAIN (costs off) asserts that the
@@ -112,21 +111,37 @@ MATCH (x:p) WHERE x = x RETURN count(*);
 MATCH (x:p), (y:p) WHERE x = id(y) RETURN count(*);
 
 --
--- The identity need not be unique for either spelling to be right
+-- Two labels cannot share an identity
 --
--- Give a q vertex a p vertex's graphid.  Both spellings then match the pair,
--- because both ask the same question.
+-- The first part of a graphid is the label that stores the row, so giving a q
+-- vertex a p vertex's graphid is refused, and elements of two labels are never
+-- equal.
 --
 SET enable_graph_dml = on;
 INSERT INTO ei.q (id, properties)
   SELECT id, '{"n": "clone"}'::jsonb FROM ei.p ORDER BY id LIMIT 1;
 RESET enable_graph_dml;
 
-MATCH (x:p), (y:q) WHERE x = y RETURN x.n, y.n;
-MATCH (x:p), (y:q) WHERE id(x) = id(y) RETURN x.n, y.n;
+MATCH (x:p), (y:q) WHERE x = y RETURN count(*);
+MATCH (x:p), (y:q) WHERE id(x) = id(y) RETURN count(*);
 
+-- COPY writes a row without going through parse analysis, and is refused just
+-- the same; 9999 is no label of this graph
+COPY ei.q (id, properties) FROM STDIN;
+9999.1	{"n": "copied"}
+\.
+
+-- and so is moving a row that is already there onto another label's id
 SET enable_graph_dml = on;
-DELETE FROM ei.q WHERE properties->>'n' = 'clone';
+UPDATE ei.q SET id = graphid(9999, 1) WHERE properties->>'n' = 'z';
+
+-- an edge label is named by its id the same way
+UPDATE ei.k SET id = graphid(9999, 1);
+
+-- what the label's own default produces is accepted, so an ordinary SQL write
+-- of a graph element still works
+INSERT INTO ei.q (properties) VALUES ('{"n": "sql"}');
+DELETE FROM ei.q WHERE properties->>'n' = 'sql';
 RESET enable_graph_dml;
 
 --


### PR DESCRIPTION
A graphid carries the label that stores the row in its first part, and the planner reads it: a constant id filter prunes an inheritance scan to the one label that id names.  Everything that reads a label off an element does the same.  Nothing enforced it, so a row could be stored under an id belonging to another label, and then MATCH (n) WHERE id(n) = <that id> returned nothing while reading the label itself returned the row.  The graph reported no error, and a dump, a restore and pg_upgrade all carried the row across.

The id is now checked where every write path already meets: a Cypher write, an INSERT, an UPDATE, COPY and a logical replication apply all reach ExecConstraints, and the label a result relation writes to is looked up once for the statement.  A write whose id names another label is refused and says which label the id names.

The graph DML setting is not what was missing.  A superuser INSERT with the setting on stored the same row and lost it from MATCH the same way, so the setting gates the SQL spelling rather than the integrity.  COPY is one of the three ways in, not the cause.