### PR TITLE
fix: complete the catalog descriptor for a graph and a label

### DIFF
--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -639,45 +639,70 @@ static const ObjectPropertyType ObjectProperty[] =
 		OBJECT_USER_MAPPING,
 		false
 	},
-	/* for agensgraph */
+	/*
+	 * for agensgraph
+	 *
+	 * Written by field name, unlike the rows above: a field left out then
+	 * keeps its own zero -- InvalidAttrNumber for a column number, which every
+	 * reader tests before reading one -- instead of taking the next field's
+	 * value.
+	 *
+	 * Neither catalog has an owner or an ACL column, and neither object sits
+	 * in a schema: a graph is one, and a label is placed by its graph, whose
+	 * oid is not a namespace oid.
+	 */
 	{
-		"graph",
-		GraphRelationId,
-		GraphOidIndexId,
-		GRAPHOID,
-		GRAPHNAME,
-		Anum_ag_graph_graphname,
-		InvalidAttrNumber,
-		InvalidAttrNumber,
-		InvalidAttrNumber,
-		OBJECT_GRAPH,
-		true,
+		.class_descr = "graph",
+		.class_oid = GraphRelationId,
+		.oid_index_oid = GraphOidIndexId,
+		.oid_catcache_id = GRAPHOID,
+		.name_catcache_id = GRAPHNAME,
+		.attnum_oid = Anum_ag_graph_oid,
+		.attnum_name = Anum_ag_graph_graphname,
+		.attnum_namespace = InvalidAttrNumber,
+		.attnum_owner = InvalidAttrNumber,
+		.attnum_acl = InvalidAttrNumber,
+		.objtype = OBJECT_GRAPH,
+		/* a graph's name is a schema name, so it identifies the graph by itself */
+		.is_nsp_name_unique = true,
 	},
 	{
-		"vlabel",
-		LabelRelationId,
-		LabelOidIndexId,
-		LABELOID,
-		LABELNAMEGRAPH,
-		Anum_ag_label_labname,
-		InvalidAttrNumber,
-		InvalidAttrNumber,
-		InvalidAttrNumber,
-		OBJECT_VLABEL,
-		true,
+		.class_descr = "vlabel",
+		.class_oid = LabelRelationId,
+		.oid_index_oid = LabelOidIndexId,
+		.oid_catcache_id = LABELOID,
+		.name_catcache_id = LABELNAMEGRAPH,
+		.attnum_oid = Anum_ag_label_oid,
+		.attnum_name = Anum_ag_label_labname,
+		.attnum_namespace = InvalidAttrNumber,
+		.attnum_owner = InvalidAttrNumber,
+		.attnum_acl = InvalidAttrNumber,
+		.objtype = OBJECT_VLABEL,
+
+		/*
+		 * A label name is unique only inside its graph -- ag_label is keyed on
+		 * (labname, graphid) -- and the graph is not reported as a namespace.
+		 */
+		.is_nsp_name_unique = false,
 	},
+
+	/*
+	 * A row is found by catalog, so this one is never the row returned for
+	 * ag_label.  It records what an edge label is; the row above answers.
+	 */
 	{
-		"elabel",
-		LabelRelationId,
-		LabelOidIndexId,
-		LABELOID,
-		LABELNAMEGRAPH,
-		Anum_ag_label_labname,
-		InvalidAttrNumber,
-		InvalidAttrNumber,
-		InvalidAttrNumber,
-		OBJECT_ELABEL,
-		true,
+		.class_descr = "elabel",
+		.class_oid = LabelRelationId,
+		.oid_index_oid = LabelOidIndexId,
+		.oid_catcache_id = LABELOID,
+		.name_catcache_id = LABELNAMEGRAPH,
+		.attnum_oid = Anum_ag_label_oid,
+		.attnum_name = Anum_ag_label_labname,
+		.attnum_namespace = InvalidAttrNumber,
+		.attnum_owner = InvalidAttrNumber,
+		.attnum_acl = InvalidAttrNumber,
+		.objtype = OBJECT_ELABEL,
+		.is_nsp_name_unique = false,
 	},
 };
 

--- a/src/test/regress/expected/cypher_ddl.out
+++ b/src/test/regress/expected/cypher_ddl.out
@@ -995,6 +995,53 @@ DROP TABLE my_vertices;
 DROP TABLE my_edges;
 DROP TABLE my_detailed_paths;
 --
+-- pg_identify_object / pg_get_acl
+--
+CREATE GRAPH objdesc;
+SET graph_path = objdesc;
+CREATE VLABEL person;
+CREATE ELABEL knows;
+-- a second graph with a label of the same name
+CREATE GRAPH objdesc2;
+SET graph_path = objdesc2;
+CREATE VLABEL person;
+SET graph_path = objdesc;
+-- a graph's name identifies it, so it is reported
+SELECT type, coalesce(name, '(null)') AS name, identity
+  FROM pg_identify_object('ag_graph'::regclass,
+                          (SELECT oid FROM ag_graph WHERE graphname = 'objdesc'), 0);
+ type  |  name   | identity 
+-------+---------+----------
+ graph | objdesc | objdesc
+(1 row)
+
+-- a label's name does not, so only the identity carries it
+SELECT i.type, coalesce(i.name, '(null)') AS name, i.identity
+  FROM ag_label l
+  JOIN ag_graph g ON g.oid = l.graphid,
+       LATERAL pg_identify_object('ag_label'::regclass, l.oid, 0) i
+ WHERE g.graphname = 'objdesc' AND l.labname IN ('person', 'knows')
+ ORDER BY i.identity;
+  type  |  name  |    identity    
+--------+--------+----------------
+ elabel | (null) | objdesc.knows
+ vlabel | (null) | objdesc.person
+(2 rows)
+
+-- neither catalog has an ACL column, so this answers null
+SELECT count(*) AS rows, count(pg_get_acl(classid, objid, objsubid)) AS acls
+  FROM pg_depend
+ WHERE classid IN ('ag_graph'::regclass, 'ag_label'::regclass);
+ rows | acls 
+------+------
+   22 |    0
+(1 row)
+
+DROP GRAPH objdesc2 CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DROP GRAPH objdesc CASCADE;
+NOTICE:  drop cascades to 5 other objects
+--
 -- DROP GRAPH
 --
 DROP GRAPH ddl;

--- a/src/test/regress/sql/cypher_ddl.sql
+++ b/src/test/regress/sql/cypher_ddl.sql
@@ -466,6 +466,40 @@ DROP TABLE my_edges;
 DROP TABLE my_detailed_paths;
 
 --
+-- pg_identify_object / pg_get_acl
+--
+CREATE GRAPH objdesc;
+SET graph_path = objdesc;
+CREATE VLABEL person;
+CREATE ELABEL knows;
+-- a second graph with a label of the same name
+CREATE GRAPH objdesc2;
+SET graph_path = objdesc2;
+CREATE VLABEL person;
+SET graph_path = objdesc;
+
+-- a graph's name identifies it, so it is reported
+SELECT type, coalesce(name, '(null)') AS name, identity
+  FROM pg_identify_object('ag_graph'::regclass,
+                          (SELECT oid FROM ag_graph WHERE graphname = 'objdesc'), 0);
+
+-- a label's name does not, so only the identity carries it
+SELECT i.type, coalesce(i.name, '(null)') AS name, i.identity
+  FROM ag_label l
+  JOIN ag_graph g ON g.oid = l.graphid,
+       LATERAL pg_identify_object('ag_label'::regclass, l.oid, 0) i
+ WHERE g.graphname = 'objdesc' AND l.labname IN ('person', 'knows')
+ ORDER BY i.identity;
+
+-- neither catalog has an ACL column, so this answers null
+SELECT count(*) AS rows, count(pg_get_acl(classid, objid, objsubid)) AS acls
+  FROM pg_depend
+ WHERE classid IN ('ag_graph'::regclass, 'ag_label'::regclass);
+
+DROP GRAPH objdesc2 CASCADE;
+DROP GRAPH objdesc CASCADE;
+
+--
 -- DROP GRAPH
 --
 DROP GRAPH ddl;


### PR DESCRIPTION
One row of the table that describes a catalog to everything asking a generic question about it -- what is this object called, what is it, what may be granted on it -- carries twelve fields.  The rows for graph, vlabel and elabel gave eleven.  A positional initialiser that runs short does not fail to compile: every value from the sixth onward moved into the field beside it, and the field left over at the end was filled with a zero.

So the field naming the name column held nothing, and a graph answered with no name at all.  The field naming the access-privileges column held an ObjectType constant -- 21, 55 and 14 -- and that number is used as a column number to read the tuple with.  ag_graph has four columns and ag_label has six, so asking either for its privileges read past the end of the row: with assertions the session ends and the server restarts, without them it reads whatever is there. The field saying what kind of object it is held a 1, which is an aggregate.

The fields are written by name now.  A row that runs short then leaves whatever it did not mention where it stands instead of moving its neighbours along, and zero is a value those fields already mean something safe by: for a column number it is InvalidAttrNumber, "this catalog has no such column", which every reader tests for before reading one.

A label goes on answering with no name, and that is the answer.  A name is given only when it identifies the object, and two graphs may each hold a person, so it does not -- ag_label is unique on (labname, graphid).  The graph is not offered as the namespace that would tell them apart either, because a label is placed by a graph whose oid is not a namespace oid.  What names a label is its identity, which carries the graph and always did.

Event triggers still see nothing of graph DDL; that is a separate refusal, in EventTriggerSupportsObjectType(), and is untouched here.