### PR TITLE
fix: report a malformed graphid through the caller's error context

### DIFF
--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -11,6 +11,7 @@
 #include "postgres.h"
 
 #include "nodes/makefuncs.h"
+#include "nodes/miscnodes.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/supportnodes.h"
 #include "optimizer/optimizer.h"
@@ -72,6 +73,8 @@ typedef struct LabelsOutData
 	Jsonb	   *labels;
 } LabelsOutData;
 
+static bool graphid_from_cstring(const char *str, Graphid *result,
+								 Node *escontext);
 static void graphid_out_si(StringInfo si, Datum graphid);
 static int	graphid_cmp(FunctionCallInfo fcinfo);
 static Jsonb *int_to_jsonb(int i);
@@ -114,39 +117,11 @@ graphid(PG_FUNCTION_ARGS)
 Datum
 graphid_in(PG_FUNCTION_ARGS)
 {
-	const char	GRAPHID_DELIM = '.';
 	char	   *str = PG_GETARG_CSTRING(0);
-	char	   *next;
-	char	   *endptr;
-	unsigned long labid_ul;
-	uint16		labid;
-	uint64		locid;
 	Graphid		id;
 
-	errno = 0;
-	labid_ul = strtoul(str, &endptr, 10);
-	if (errno != 0 || endptr == str || *endptr != GRAPHID_DELIM)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid input syntax for type graphid: \"%s\"", str)));
-	if (labid_ul > GRAPHID_LABID_MAX)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("labid out of range")));
-	labid = (uint16) labid_ul;
-
-	next = endptr + 1;
-	locid = strtoull(next, &endptr, 10);
-	if (errno != 0 || endptr == next || *endptr != '\0')
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
-				 errmsg("invalid input syntax for type graphid: \"%s\"", str)));
-	if (locid > GRAPHID_LOCID_MAX)
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("locid out of range")));
-
-	GraphidSet(&id, labid, locid);
+	if (!graphid_from_cstring(str, &id, fcinfo->context))
+		PG_RETURN_NULL();
 
 	PG_RETURN_GRAPHID(id);
 }
@@ -253,14 +228,15 @@ graphid_ne(PG_FUNCTION_ARGS)
 }
 
 /*
- * Parse a graphid out of a (not necessarily NUL-terminated) string of the form
- * "labid.locid".  Unlike graphid_in(), a malformed string yields false rather
- * than an error, because this is used to test membership against an arbitrary
- * jsonb array whose elements need not be graphids: a non-graphid element simply
- * cannot be a member and must be skipped, not rejected.
+ * Parse a graphid out of a NUL-terminated string of the form "labid.locid".
+ *
+ * The error goes through escontext: NULL throws it, which is what reading a
+ * value of the type does, and an ErrorSaveContext takes it and leaves false to
+ * be returned -- which is what the error-tolerant paths ask for, and what
+ * asking whether some string happens to be a graphid asks for.
  */
 static bool
-graphid_from_cstring(const char *str, Graphid *result)
+graphid_from_cstring(const char *str, Graphid *result, Node *escontext)
 {
 	const char	GRAPHID_DELIM = '.';
 	char	   *endptr;
@@ -272,18 +248,26 @@ graphid_from_cstring(const char *str, Graphid *result)
 	errno = 0;
 	labid_ul = strtoul(str, &endptr, 10);
 	if (errno != 0 || endptr == str || *endptr != GRAPHID_DELIM)
-		return false;
+		ereturn(escontext, false,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid input syntax for type graphid: \"%s\"", str)));
 	if (labid_ul > GRAPHID_LABID_MAX)
-		return false;
+		ereturn(escontext, false,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("labid out of range")));
 	labid = (uint16) labid_ul;
 
 	next = endptr + 1;
 	errno = 0;
 	locid = strtoull(next, &endptr, 10);
 	if (errno != 0 || endptr == next || *endptr != '\0')
-		return false;
+		ereturn(escontext, false,
+				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+				 errmsg("invalid input syntax for type graphid: \"%s\"", str)));
 	if (locid > GRAPHID_LOCID_MAX)
-		return false;
+		ereturn(escontext, false,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("locid out of range")));
 
 	GraphidSet(result, labid, locid);
 	return true;
@@ -309,6 +293,13 @@ graphid_in_jsonb_array(PG_FUNCTION_ARGS)
 	JsonbContainer *jc = &arr->root;
 	int			n;
 	int			i;
+
+	/*
+	 * An element that is not a graphid is not a member, so the error is wanted
+	 * only as the false it returns.  Leaving details_wanted off keeps the
+	 * parser from composing a message nothing here reads.
+	 */
+	ErrorSaveContext escontext = {T_ErrorSaveContext};
 
 	/*
 	 * A naked jsonb scalar is stored as a one-element pseudo-array flagged
@@ -353,7 +344,8 @@ graphid_in_jsonb_array(PG_FUNCTION_ARGS)
 		memcpy(buf, idval->val.string.val, idval->val.string.len);
 		buf[idval->val.string.len] = '\0';
 
-		if (graphid_from_cstring(buf, &elemid) && elemid == id)
+		if (graphid_from_cstring(buf, &elemid, (Node *) &escontext) &&
+			elemid == id)
 			PG_RETURN_BOOL(true);
 	}
 

--- a/src/test/regress/expected/graphid.out
+++ b/src/test/regress/expected/graphid.out
@@ -192,3 +192,116 @@ SELECT g.* FROM GRAPHID_TBL g WHERE g.f1 <= '12345.123'::graphid;
 
 SET enable_seqscan = on;
 DROP TABLE GRAPHID_TBL;
+-- Soft errors
+SELECT pg_input_is_valid('1.1', 'graphid');
+ pg_input_is_valid 
+-------------------
+ t
+(1 row)
+
+SELECT pg_input_is_valid('nodelim', 'graphid');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+SELECT pg_input_is_valid('99999999.1', 'graphid');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+SELECT pg_input_is_valid('1.x', 'graphid');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+SELECT pg_input_is_valid('1.288230376151711744', 'graphid');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+-- each answer is the one the hard path raises
+SELECT message, sql_error_code FROM pg_input_error_info('nodelim', 'graphid');
+                     message                      | sql_error_code 
+--------------------------------------------------+----------------
+ invalid input syntax for type graphid: "nodelim" | 22P02
+(1 row)
+
+SELECT message, sql_error_code FROM pg_input_error_info('99999999.1', 'graphid');
+      message       | sql_error_code 
+--------------------+----------------
+ labid out of range | 22023
+(1 row)
+
+SELECT message, sql_error_code FROM pg_input_error_info('1.x', 'graphid');
+                   message                    | sql_error_code 
+----------------------------------------------+----------------
+ invalid input syntax for type graphid: "1.x" | 22P02
+(1 row)
+
+SELECT message, sql_error_code FROM pg_input_error_info('1.288230376151711744', 'graphid');
+      message       | sql_error_code 
+--------------------+----------------
+ locid out of range | 22023
+(1 row)
+
+-- an array, a domain and a composite arrive at the same input function
+CREATE DOMAIN GRAPHID_DOM AS graphid;
+CREATE TYPE GRAPHID_COMP AS (f1 graphid);
+SELECT pg_input_is_valid('{1.1,bad}', 'graphid[]');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+SELECT pg_input_is_valid('bad', 'GRAPHID_DOM');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+SELECT pg_input_is_valid('(bad)', 'GRAPHID_COMP');
+ pg_input_is_valid 
+-------------------
+ f
+(1 row)
+
+DROP TYPE GRAPHID_COMP;
+DROP DOMAIN GRAPHID_DOM;
+-- COPY skips the row it cannot read
+CREATE TABLE GRAPHID_COPY_TBL(f1 graphid);
+COPY GRAPHID_COPY_TBL FROM STDIN WITH (on_error ignore);
+NOTICE:  1 row was skipped due to data type incompatibility
+SELECT * FROM GRAPHID_COPY_TBL ORDER BY f1;
+ f1  
+-----
+ 1.1
+ 2.2
+(2 rows)
+
+DROP TABLE GRAPHID_COPY_TBL;
+-- JSON_TABLE takes its default instead
+SELECT * FROM JSON_TABLE('[{"g":"bad"},{"g":"7.7"}]', '$[*]'
+       COLUMNS (g graphid PATH '$.g' DEFAULT '0.0'::graphid ON ERROR));
+  g  
+-----
+ 0.0
+ 7.7
+(2 rows)
+
+-- an element that is not a graphid is not a member, and says nothing
+SELECT graphid_in_jsonb_array('2.2'::graphid, '["junk","1.1",{"id":"2.2"}]'::jsonb);
+ graphid_in_jsonb_array 
+------------------------
+ t
+(1 row)
+
+SELECT graphid_in_jsonb_array('9.9'::graphid, '["junk","more junk"]'::jsonb);
+ graphid_in_jsonb_array 
+------------------------
+ f
+(1 row)
+

--- a/src/test/regress/sql/graphid.sql
+++ b/src/test/regress/sql/graphid.sql
@@ -59,3 +59,49 @@ SELECT g.* FROM GRAPHID_TBL g WHERE g.f1 <= '12345.123'::graphid;
 SET enable_seqscan = on;
 
 DROP TABLE GRAPHID_TBL;
+
+-- Soft errors
+
+SELECT pg_input_is_valid('1.1', 'graphid');
+SELECT pg_input_is_valid('nodelim', 'graphid');
+SELECT pg_input_is_valid('99999999.1', 'graphid');
+SELECT pg_input_is_valid('1.x', 'graphid');
+SELECT pg_input_is_valid('1.288230376151711744', 'graphid');
+
+-- each answer is the one the hard path raises
+
+SELECT message, sql_error_code FROM pg_input_error_info('nodelim', 'graphid');
+SELECT message, sql_error_code FROM pg_input_error_info('99999999.1', 'graphid');
+SELECT message, sql_error_code FROM pg_input_error_info('1.x', 'graphid');
+SELECT message, sql_error_code FROM pg_input_error_info('1.288230376151711744', 'graphid');
+
+-- an array, a domain and a composite arrive at the same input function
+
+CREATE DOMAIN GRAPHID_DOM AS graphid;
+CREATE TYPE GRAPHID_COMP AS (f1 graphid);
+SELECT pg_input_is_valid('{1.1,bad}', 'graphid[]');
+SELECT pg_input_is_valid('bad', 'GRAPHID_DOM');
+SELECT pg_input_is_valid('(bad)', 'GRAPHID_COMP');
+DROP TYPE GRAPHID_COMP;
+DROP DOMAIN GRAPHID_DOM;
+
+-- COPY skips the row it cannot read
+
+CREATE TABLE GRAPHID_COPY_TBL(f1 graphid);
+COPY GRAPHID_COPY_TBL FROM STDIN WITH (on_error ignore);
+1.1
+bad
+2.2
+\.
+SELECT * FROM GRAPHID_COPY_TBL ORDER BY f1;
+DROP TABLE GRAPHID_COPY_TBL;
+
+-- JSON_TABLE takes its default instead
+
+SELECT * FROM JSON_TABLE('[{"g":"bad"},{"g":"7.7"}]', '$[*]'
+       COLUMNS (g graphid PATH '$.g' DEFAULT '0.0'::graphid ON ERROR));
+
+-- an element that is not a graphid is not a member, and says nothing
+
+SELECT graphid_in_jsonb_array('2.2'::graphid, '["junk","1.1",{"id":"2.2"}]'::jsonb);
+SELECT graphid_in_jsonb_array('9.9'::graphid, '["junk","more junk"]'::jsonb);


### PR DESCRIPTION
An input function is handed a context to report a malformed value through, and the features built on it -- pg_input_is_valid, COPY's ON_ERROR and REJECT_LIMIT, JSON_TABLE's ON ERROR -- read the answer back from that context. graphid_in ignored it and threw at each of its four refusals, so a COPY of a file holding one unreadable row loaded none of it, and pg_input_is_valid ended the statement that asked.

The same grammar was parsed in two places.  graphid_in threw; the copy in graphid_from_cstring, which reads an element of a jsonb array for a membership test, returned false and said nothing about which of the four refusals it met.

One parser serves both and reports through an escontext.  A caller with none gets the error thrown, carrying the message and the SQLSTATE it carried before, so reading a graphid on its own is unchanged.  A caller with one gets false and the reason.  An array, a domain and a composite are readable the same way, each passing its context down to the element's input function.

The membership test asks for no detail, which is what makes it free: the message is composed only for a context that wants one.  Over a 100k-element array of strings that are none of them graphids, every one reaching a refusal, it runs no slower than 100k that parse and do not match.

The second parse in graphid_in did not clear errno beforehand, so a value left from earlier could have been read as a failure to parse.  The copy that became the shared parser had always cleared it.