### PR TITLE
fix: read the integer a graph property names rather than nothing

### DIFF
--- a/src/backend/utils/adt/cypher_funcs.c
+++ b/src/backend/utils/adt/cypher_funcs.c
@@ -62,6 +62,7 @@ typedef bool (*ElemConvFn) (Datum d, Oid typeid, Datum *result);
 
 static Jsonb *FunctionCallJsonb(FunctionCallJsonbInfo *fcjinfo);
 static Datum jsonb_to_datum(Jsonb *j, Oid type);
+static bool jsonb_to_scalar_datum(Jsonb *j, Datum *result, Oid *typeid);
 static bool is_numeric_integer(Numeric n);
 static void ereport_invalid_jsonb_param(FunctionCallJsonbInfo *fcjinfo);
 static char *type_to_jsonb_type_str(Oid type);
@@ -987,6 +988,58 @@ jsonb_to_datum(Jsonb *j, Oid type)
 	}
 
 	return retval;
+}
+
+/*
+ * jsonb_to_scalar_datum
+ *		Reads a scalar jsonb as the datum and the type it names, so that a
+ *		conversion handed a graph property reads it the way it reads a value of
+ *		that type.
+ *
+ *		Unlike jsonb_to_datum(), no target type is asked for: what the jsonb
+ *		names is what comes back.  The element types are the ones
+ *		convert_jsonb_list() reads, so a scalar and a list of one element agree.
+ *
+ *		A null, a list and a map name no value: false comes back and the caller
+ *		yields null, as it already does for text that names no number.
+ */
+static bool
+jsonb_to_scalar_datum(Jsonb *j, Datum *result, Oid *typeid)
+{
+	JsonbValue *jv;
+
+	if (!JB_ROOT_IS_SCALAR(j))
+		return false;
+
+	jv = getIthJsonbValueFromContainer(&j->root, 0);
+
+	switch (jv->type)
+	{
+		case jbvString:
+
+			/*
+			 * The value is copied to its own string: its length is its own,
+			 * not that of the buffer it was read from.
+			 */
+			*result = CStringGetDatum(pnstrdup(jv->val.string.val,
+											   jv->val.string.len));
+			*typeid = CSTRINGOID;
+			return true;
+
+		case jbvNumeric:
+			*result = NumericGetDatum(jv->val.numeric);
+			*typeid = NUMERICOID;
+			return true;
+
+		case jbvBool:
+			*result = BoolGetDatum(jv->val.boolean);
+			*typeid = BOOLOID;
+			return true;
+
+		default:
+			/* a null, a list or a map names no value */
+			return false;
+	}
 }
 
 static bool
@@ -2542,6 +2595,24 @@ datum_to_int64(Datum d, Oid typeid, int64 *result)
 					return false;
 
 				return string_to_int64(s, result);
+			}
+
+		case JSONBOID:
+			{
+				Datum		sd;
+				Oid			stypeid;
+
+				/*
+				 * Every graph property is a jsonb, so the scalar one names is
+				 * read as a value of the type it names.  Reading it here is
+				 * what makes toInteger(v.prop) agree with
+				 * toIntegerList([v.prop]): the list walk reads the same
+				 * scalar the same way.
+				 */
+				if (!jsonb_to_scalar_datum(DatumGetJsonbP(d), &sd, &stypeid))
+					return false;
+
+				return datum_to_int64(sd, stypeid, result);
 			}
 
 		default:

--- a/src/test/regress/expected/cypher_func.out
+++ b/src/test/regress/expected/cypher_func.out
@@ -1357,3 +1357,74 @@ drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
 drop cascades to vlabel p
 drop cascades to elabel r
+--
+-- AGV2-360
+--
+-- Every graph property is a jsonb, so toInteger() handed one reads the scalar
+-- it names.  Read any other way it answers null for a property that plainly
+-- names a number, while the same value in a list answers the number: a scalar
+-- and a list of one element have to agree.
+CREATE GRAPH tointeger_graph;
+SET graph_path = tointeger_graph;
+CREATE (:p {i: 42, f: 1.5, s: '42', words: 'abc', b: true, l: [1, 2], m: {a: 1}});
+-- a property naming a number reads as that number
+MATCH (v:p) RETURN toInteger(v.i);
+ tointeger 
+-----------
+ 42
+(1 row)
+
+-- one naming a number with a fraction reads as its whole part
+MATCH (v:p) RETURN toInteger(v.f);
+ tointeger 
+-----------
+ 1
+(1 row)
+
+-- one naming a number as text reads as that number
+MATCH (v:p) RETURN toInteger(v.s);
+ tointeger 
+-----------
+ 42
+(1 row)
+
+-- a boolean reads the way it reads everywhere else
+MATCH (v:p) RETURN toInteger(v.b);
+ tointeger 
+-----------
+ 1
+(1 row)
+
+-- text naming no number is null, and so are a list, a map, and a property
+-- that is not there
+MATCH (v:p)
+	RETURN toInteger(v.words) IS NULL, toInteger(v.l) IS NULL,
+		toInteger(v.m) IS NULL, toInteger(v.missing) IS NULL;
+ ?column? | ?column? | ?column? | ?column? 
+----------+----------+----------+----------
+ t        | t        | t        | t
+(1 row)
+
+-- the same values given as jsonb, so the scalar and the list of one element
+-- can be read against each other form by form
+SELECT j, toInteger(j), toIntegerList(('[' || j::text || ']')::jsonb)
+FROM (VALUES ('42'::jsonb), ('1.2'), ('"42"'), ('"abc"'), ('true'), ('null'),
+	('[1,2]'), ('{"a":1}')) v(j);
+    j     | tointeger | tointegerlist 
+----------+-----------+---------------
+ 42       |        42 | [42]
+ 1.2      |         1 | [1]
+ "42"     |        42 | [42]
+ "abc"    |           | [null]
+ true     |         1 | [1]
+ null     |           | [null]
+ [1, 2]   |           | [null]
+ {"a": 1} |           | [null]
+(8 rows)
+
+DROP GRAPH tointeger_graph CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to sequence tointeger_graph.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel p

--- a/src/test/regress/sql/cypher_func.sql
+++ b/src/test/regress/sql/cypher_func.sql
@@ -590,3 +590,37 @@ RETURN toIntegerList([
 	'11111111111111111111111111111111111111111111111111111111111111111111', 1]);
 
 DROP GRAPH list_graph CASCADE;
+
+--
+-- AGV2-360
+--
+-- Every graph property is a jsonb, so toInteger() handed one reads the scalar
+-- it names.  Read any other way it answers null for a property that plainly
+-- names a number, while the same value in a list answers the number: a scalar
+-- and a list of one element have to agree.
+CREATE GRAPH tointeger_graph;
+SET graph_path = tointeger_graph;
+
+CREATE (:p {i: 42, f: 1.5, s: '42', words: 'abc', b: true, l: [1, 2], m: {a: 1}});
+
+-- a property naming a number reads as that number
+MATCH (v:p) RETURN toInteger(v.i);
+-- one naming a number with a fraction reads as its whole part
+MATCH (v:p) RETURN toInteger(v.f);
+-- one naming a number as text reads as that number
+MATCH (v:p) RETURN toInteger(v.s);
+-- a boolean reads the way it reads everywhere else
+MATCH (v:p) RETURN toInteger(v.b);
+-- text naming no number is null, and so are a list, a map, and a property
+-- that is not there
+MATCH (v:p)
+	RETURN toInteger(v.words) IS NULL, toInteger(v.l) IS NULL,
+		toInteger(v.m) IS NULL, toInteger(v.missing) IS NULL;
+
+-- the same values given as jsonb, so the scalar and the list of one element
+-- can be read against each other form by form
+SELECT j, toInteger(j), toIntegerList(('[' || j::text || ']')::jsonb)
+FROM (VALUES ('42'::jsonb), ('1.2'), ('"42"'), ('"abc"'), ('true'), ('null'),
+	('[1,2]'), ('{"a":1}')) v(j);
+
+DROP GRAPH tointeger_graph CASCADE;


### PR DESCRIPTION
Fixes AGV2-360 — toInteger() already exists; it had no case for jsonb, which every graph property is, so toInteger(v.prop) answered null silently. This adds that input path.

- Regression 252/252, plus a negative control.
- A jsonb null, list or map stays null rather than raising, matching what toInteger() does for SQL values and list elements. Apache AGE raises instead; say if you prefer that.
- AGV2-361 (toFloat) follows once this merges.

---

Fixes AGV2-360 — `toInteger()` 는 이미 있습니다. `jsonb` 분기만 없어서, 그래프 속성이 전부 `jsonb` 인 탓에 `toInteger(v.prop)` 이 조용히 null 이었습니다. 이 입력 경로 하나를 더합니다.

- 회귀 252/252, 음성 대조군 확인.
- jsonb null·리스트·맵은 오류가 아니라 null 유지입니다. SQL 값·리스트 원소에 대한 `toInteger()` 의 기존 동작과 같습니다. Apache AGE 는 오류를 내니 그쪽이 낫다면 말씀해 주세요.
- AGV2-361(toFloat)은 이 PR 병합 후 올립니다.
