### PR TITLE
fix: read the float a graph property names rather than nothing

### DIFF
--- a/src/backend/utils/adt/cypher_funcs.c
+++ b/src/backend/utils/adt/cypher_funcs.c
@@ -2744,6 +2744,24 @@ datum_to_float8(Datum d, Oid typeid, float8 *result)
 				return string_to_float8(s, result);
 			}
 
+		case JSONBOID:
+			{
+				Datum		sd;
+				Oid			stypeid;
+
+				/*
+				 * Every graph property is a jsonb, so the scalar one names is
+				 * read as a value of the type it names.  Reading it here is
+				 * what makes toFloat(v.prop) agree with
+				 * toFloatList([v.prop]): the list walk reads the same scalar
+				 * the same way.
+				 */
+				if (!jsonb_to_scalar_datum(DatumGetJsonbP(d), &sd, &stypeid))
+					return false;
+
+				return datum_to_float8(sd, stypeid, result);
+			}
+
 		default:
 			return false;
 	}

--- a/src/test/regress/expected/cypher_func.out
+++ b/src/test/regress/expected/cypher_func.out
@@ -1428,3 +1428,65 @@ DETAIL:  drop cascades to sequence tointeger_graph.ag_label_seq
 drop cascades to vlabel ag_vertex
 drop cascades to elabel ag_edge
 drop cascades to vlabel p
+--
+-- AGV2-361
+--
+-- toFloat() reads a graph property the same way, so a property and the same
+-- value inside a list give the same number.
+CREATE GRAPH tofloat_graph;
+SET graph_path = tofloat_graph;
+CREATE (:p {i: 42, f: 1.5, s: '1.5', words: 'abc', b: true, l: [1, 2], m: {a: 1}});
+-- a property naming a number reads as that number, fraction and all
+MATCH (v:p) RETURN toFloat(v.f), toFloat(v.i);
+ tofloat | tofloat 
+---------+---------
+ 1.5     | 42
+(1 row)
+
+-- one naming a number as text reads as that number
+MATCH (v:p) RETURN toFloat(v.s);
+ tofloat 
+---------
+ 1.5
+(1 row)
+
+-- a boolean reads the way it reads everywhere else
+MATCH (v:p) RETURN toFloat(v.b);
+ tofloat 
+---------
+ 1
+(1 row)
+
+-- text naming no number is null, and so are a list, a map, and a property
+-- that is not there
+MATCH (v:p)
+	RETURN toFloat(v.words) IS NULL, toFloat(v.l) IS NULL,
+		toFloat(v.m) IS NULL, toFloat(v.missing) IS NULL;
+ ?column? | ?column? | ?column? | ?column? 
+----------+----------+----------+----------
+ t        | t        | t        | t
+(1 row)
+
+-- the same values given as jsonb, so the scalar and the list of one element
+-- can be read against each other form by form
+SELECT j, toFloat(j), toFloatList(('[' || j::text || ']')::jsonb)
+FROM (VALUES ('1.5'::jsonb), ('42'), ('"1.5"'), ('"abc"'), ('true'), ('null'),
+	('[1,2]'), ('{"a":1}')) v(j);
+    j     | tofloat | tofloatlist 
+----------+---------+-------------
+ 1.5      |     1.5 | [1.5]
+ 42       |      42 | [42]
+ "1.5"    |     1.5 | [1.5]
+ "abc"    |         | [null]
+ true     |       1 | [1]
+ null     |         | [null]
+ [1, 2]   |         | [null]
+ {"a": 1} |         | [null]
+(8 rows)
+
+DROP GRAPH tofloat_graph CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to sequence tofloat_graph.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel p

--- a/src/test/regress/sql/cypher_func.sql
+++ b/src/test/regress/sql/cypher_func.sql
@@ -624,3 +624,33 @@ FROM (VALUES ('42'::jsonb), ('1.2'), ('"42"'), ('"abc"'), ('true'), ('null'),
 	('[1,2]'), ('{"a":1}')) v(j);
 
 DROP GRAPH tointeger_graph CASCADE;
+
+--
+-- AGV2-361
+--
+-- toFloat() reads a graph property the same way, so a property and the same
+-- value inside a list give the same number.
+CREATE GRAPH tofloat_graph;
+SET graph_path = tofloat_graph;
+
+CREATE (:p {i: 42, f: 1.5, s: '1.5', words: 'abc', b: true, l: [1, 2], m: {a: 1}});
+
+-- a property naming a number reads as that number, fraction and all
+MATCH (v:p) RETURN toFloat(v.f), toFloat(v.i);
+-- one naming a number as text reads as that number
+MATCH (v:p) RETURN toFloat(v.s);
+-- a boolean reads the way it reads everywhere else
+MATCH (v:p) RETURN toFloat(v.b);
+-- text naming no number is null, and so are a list, a map, and a property
+-- that is not there
+MATCH (v:p)
+	RETURN toFloat(v.words) IS NULL, toFloat(v.l) IS NULL,
+		toFloat(v.m) IS NULL, toFloat(v.missing) IS NULL;
+
+-- the same values given as jsonb, so the scalar and the list of one element
+-- can be read against each other form by form
+SELECT j, toFloat(j), toFloatList(('[' || j::text || ']')::jsonb)
+FROM (VALUES ('1.5'::jsonb), ('42'), ('"1.5"'), ('"abc"'), ('true'), ('null'),
+	('[1,2]'), ('{"a":1}')) v(j);
+
+DROP GRAPH tofloat_graph CASCADE;


### PR DESCRIPTION
Fixes AGV2-361 — the same gap as AGV2-360, one function over: toFloat() had no jsonb branch, so toFloat(v.prop) answered null silently. This adds it, reusing the helper #832 introduced.

- Regression 252/252, with a negative control.
- A jsonb null, list or map stays null rather than raising, as in #832.
- Shares the end of cypher_func.sql with AGV2-355 (#833); I rebase whichever merges second.

---

Fixes AGV2-361 — AGV2-360 과 같은 공백이 한 함수 건너 있었습니다. `toFloat()` 에 jsonb 분기가 없어 `toFloat(v.prop)` 이 조용히 null 이었습니다. #832 가 만든 헬퍼를 재사용해 그 경로를 더합니다.

- 회귀 252/252, 음성 대조군 확인.
- jsonb null·리스트·맵은 #832 와 같이 오류가 아니라 null 입니다.
- `cypher_func.sql` 끝을 AGV2-355(#833)와 공유합니다. 나중에 머지되는 쪽을 제가 리베이스합니다.
