### PR TITLE
feat: read the degrees of a vertex, or of every vertex, from the meta extension

### DIFF
--- a/contrib/meta/expected/meta.out
+++ b/contrib/meta/expected/meta.out
@@ -621,6 +621,105 @@ FILTER label_name = 'person' RETURN label_name;
  "person"
 (1 row)
 
+--
+-- meta.vertex_stats()
+--
+-- Reading every vertex takes one pass over the edges, so the whole graph costs
+-- one query rather than one query for each vertex.
+--
+CREATE GRAPH stats_graph;
+SET graph_path = stats_graph;
+CREATE (:node {n: 'a'}), (:node {n: 'b'}), (:node {n: 'c'}), (:node {n: 'd'});
+MATCH (a:node {n: 'a'}), (b:node {n: 'b'}) CREATE (a)-[:link]->(b);
+MATCH (a:node {n: 'a'}), (c:node {n: 'c'}) CREATE (a)-[:link]->(c);
+MATCH (b:node {n: 'b'}), (a:node {n: 'a'}) CREATE (b)-[:link]->(a);
+-- a self-loop is counted on its own and in both degrees
+MATCH (b:node {n: 'b'}) CREATE (b)-[:link]->(b);
+-- every vertex, including the one no edge touches
+SELECT n.properties->>'n' AS vertex, s.label, s.in_degree, s.out_degree,
+       s.self_loops
+FROM meta.vertex_stats() s JOIN stats_graph.node n ON n.id = s.id
+ORDER BY vertex;
+ vertex | label | in_degree | out_degree | self_loops 
+--------+-------+-----------+------------+------------
+ a      | node  |         1 |          2 |          0
+ b      | node  |         2 |          2 |          1
+ c      | node  |         1 |          0 |          0
+ d      | node  |         0 |          0 |          0
+(4 rows)
+
+-- one vertex, named by the vertex itself
+MATCH (b:node {n: 'b'})
+CALL meta.vertex_stats(b) YIELD label, in_degree, out_degree, self_loops
+RETURN label, in_degree, out_degree, self_loops;
+ label  | in_degree | out_degree | self_loops 
+--------+-----------+------------+------------
+ "node" | 2         | 2          | 1
+(1 row)
+
+MATCH (d:node {n: 'd'})
+CALL meta.vertex_stats(d) YIELD label, in_degree, out_degree, self_loops
+RETURN label, in_degree, out_degree, self_loops;
+ label  | in_degree | out_degree | self_loops 
+--------+-----------+------------+------------
+ "node" | 0         | 0          | 0
+(1 row)
+
+-- a label that inherits another is named as itself, and an edge label that
+-- inherits another is still counted
+CREATE VLABEL employee INHERITS (node);
+CREATE ELABEL reports INHERITS (link);
+CREATE (:employee {n: 'e'});
+MATCH (a:node {n: 'a'}), (e:employee {n: 'e'}) CREATE (a)-[:reports]->(e);
+SELECT n.properties->>'n' AS vertex, s.label, s.in_degree, s.out_degree,
+       s.self_loops
+FROM meta.vertex_stats() s JOIN stats_graph.ag_vertex n ON n.id = s.id
+WHERE n.properties->>'n' IN ('a', 'e')
+ORDER BY vertex;
+ vertex |  label   | in_degree | out_degree | self_loops 
+--------+----------+-----------+------------+------------
+ a      | node     |         1 |          3 |          0
+ e      | employee |         1 |          0 |          0
+(2 rows)
+
+-- a vertex the graph does not hold gives no row at all, even where the label
+-- the id names is one the graph has
+SELECT count(*) AS rows
+FROM meta.vertex_stats(ROW(graphid(graphid_labid((SELECT id
+                                                  FROM stats_graph.node
+                                                  ORDER BY id LIMIT 1)),
+                                   99999),
+                           '{}'::jsonb, NULL)::vertex);
+ rows 
+------
+    0
+(1 row)
+
+-- the graph can be named instead of read from graph_path
+SELECT count(*) FROM meta.vertex_stats(NULL, 'stats_graph');
+ count 
+-------
+     5
+(1 row)
+
+-- and a preceding clause drives the whole-graph form as it does the others
+UNWIND [1] AS x CALL meta.vertex_stats() YIELD id, out_degree
+RETURN count(id), sum(out_degree);
+ count | sum 
+-------+-----
+ 5     | 5
+(1 row)
+
+DROP GRAPH stats_graph CASCADE;
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to sequence stats_graph.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel node
+drop cascades to elabel link
+drop cascades to vlabel employee
+drop cascades to elabel reports
+SET graph_path = graph1;
 -- clean up
 DROP GRAPH graph1 CASCADE;
 NOTICE:  drop cascades to 8 other objects

--- a/contrib/meta/meta--1.0.sql
+++ b/contrib/meta/meta--1.0.sql
@@ -788,3 +788,77 @@ $$;
 
 COMMENT ON FUNCTION meta.estimated_edge_density(NAME)
 IS 'Estimates edge density using Postgresql statistics (pg_class.reltuples). Uses graph_path if graph name is not provided.';
+
+CREATE FUNCTION meta.vertex_stats(v vertex DEFAULT NULL, graph name DEFAULT NULL)
+RETURNS TABLE(id graphid, label name, in_degree BIGINT, out_degree BIGINT,
+              self_loops BIGINT)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+    schema_name name;
+BEGIN
+    IF graph IS NULL THEN
+        BEGIN
+            schema_name := current_setting('graph_path');
+            IF schema_name IS NULL OR schema_name = '' THEN
+                RAISE NOTICE 'graph_path is not set. Provide graph name or set graph_path';
+                RETURN;
+            END IF;
+            graph := schema_name;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'graph_path is not set. Provide graph name or set graph_path';
+            RETURN;
+        END;
+    END IF;
+
+    IF v IS NULL THEN
+        -- Every vertex, counted in one pass over the edges.  Asking per vertex
+        -- instead costs one query each, which a graph of any size cannot pay.
+        RETURN QUERY EXECUTE format(
+            'SELECT v.id, a.labname,'
+            '       coalesce(i.c, 0) + coalesce(s.c, 0),'
+            '       coalesce(o.c, 0) + coalesce(s.c, 0),'
+            '       coalesce(s.c, 0)'
+            '  FROM %I.ag_vertex v'
+            '  JOIN ag_graph g ON g.graphname = %L'
+            '  JOIN ag_label a ON a.graphid = g.oid'
+            '                 AND a.labid = graphid_labid(v.id)'
+            '  LEFT JOIN (SELECT "end" AS id, count(*) AS c FROM %I.ag_edge'
+            '              WHERE start <> "end" GROUP BY 1) i ON i.id = v.id'
+            '  LEFT JOIN (SELECT start AS id, count(*) AS c FROM %I.ag_edge'
+            '              WHERE start <> "end" GROUP BY 1) o ON o.id = v.id'
+            '  LEFT JOIN (SELECT start AS id, count(*) AS c FROM %I.ag_edge'
+            '              WHERE start =  "end" GROUP BY 1) s ON s.id = v.id',
+            graph, graph, graph, graph, graph);
+    ELSE
+        -- One vertex, read through the indexes the edge label carries on
+        -- start and on end.  The vertex is looked up as well, so a vertex
+        -- the graph does not hold gives no row rather than a row of zeros.
+        RETURN QUERY EXECUTE format(
+            'SELECT n.id, a.labname,'
+            '       e.in_edges + e.self_edges,'
+            '       e.out_edges + e.self_edges,'
+            '       e.self_edges'
+            '  FROM (SELECT count(*) FILTER (WHERE t."end" = $1 AND t.start <> $1)'
+            '               AS in_edges,'
+            '               count(*) FILTER (WHERE t.start = $1 AND t."end" <> $1)'
+            '               AS out_edges,'
+            '               count(*) FILTER (WHERE t.start = $1 AND t."end" = $1)'
+            '               AS self_edges'
+            '          FROM (SELECT start, "end" FROM %I.ag_edge WHERE start = $1'
+            '                UNION ALL'
+            '                SELECT start, "end" FROM %I.ag_edge'
+            '                 WHERE "end" = $1 AND start <> $1) t) e'
+            '  JOIN %I.ag_vertex n ON n.id = $1'
+            '  JOIN ag_graph g ON g.graphname = %L'
+            '  JOIN ag_label a ON a.graphid = g.oid'
+            '                 AND a.labid = graphid_labid(n.id)',
+            graph, graph, graph, graph)
+        USING (v).id;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION meta.vertex_stats(vertex, name)
+IS 'Returns the id, label and degrees of a vertex, or of every vertex where none is given. A self-loop is counted in the in-degree and in the out-degree as well as on its own. Uses graph_path if graph name is not provided. An id only names one vertex within its own graph, so naming a graph other than the one the vertex was read from answers about whatever that graph holds under the same id.';

--- a/contrib/meta/sql/meta.sql
+++ b/contrib/meta/sql/meta.sql
@@ -193,6 +193,67 @@ RETURN label_name ORDER BY label_name;
 MATCH (a:person {name: 'Alice'}) CALL meta.labels() YIELD label_name
 FILTER label_name = 'person' RETURN label_name;
 
+--
+-- meta.vertex_stats()
+--
+-- Reading every vertex takes one pass over the edges, so the whole graph costs
+-- one query rather than one query for each vertex.
+--
+CREATE GRAPH stats_graph;
+SET graph_path = stats_graph;
+
+CREATE (:node {n: 'a'}), (:node {n: 'b'}), (:node {n: 'c'}), (:node {n: 'd'});
+MATCH (a:node {n: 'a'}), (b:node {n: 'b'}) CREATE (a)-[:link]->(b);
+MATCH (a:node {n: 'a'}), (c:node {n: 'c'}) CREATE (a)-[:link]->(c);
+MATCH (b:node {n: 'b'}), (a:node {n: 'a'}) CREATE (b)-[:link]->(a);
+-- a self-loop is counted on its own and in both degrees
+MATCH (b:node {n: 'b'}) CREATE (b)-[:link]->(b);
+
+-- every vertex, including the one no edge touches
+SELECT n.properties->>'n' AS vertex, s.label, s.in_degree, s.out_degree,
+       s.self_loops
+FROM meta.vertex_stats() s JOIN stats_graph.node n ON n.id = s.id
+ORDER BY vertex;
+
+-- one vertex, named by the vertex itself
+MATCH (b:node {n: 'b'})
+CALL meta.vertex_stats(b) YIELD label, in_degree, out_degree, self_loops
+RETURN label, in_degree, out_degree, self_loops;
+MATCH (d:node {n: 'd'})
+CALL meta.vertex_stats(d) YIELD label, in_degree, out_degree, self_loops
+RETURN label, in_degree, out_degree, self_loops;
+
+-- a label that inherits another is named as itself, and an edge label that
+-- inherits another is still counted
+CREATE VLABEL employee INHERITS (node);
+CREATE ELABEL reports INHERITS (link);
+CREATE (:employee {n: 'e'});
+MATCH (a:node {n: 'a'}), (e:employee {n: 'e'}) CREATE (a)-[:reports]->(e);
+SELECT n.properties->>'n' AS vertex, s.label, s.in_degree, s.out_degree,
+       s.self_loops
+FROM meta.vertex_stats() s JOIN stats_graph.ag_vertex n ON n.id = s.id
+WHERE n.properties->>'n' IN ('a', 'e')
+ORDER BY vertex;
+
+-- a vertex the graph does not hold gives no row at all, even where the label
+-- the id names is one the graph has
+SELECT count(*) AS rows
+FROM meta.vertex_stats(ROW(graphid(graphid_labid((SELECT id
+                                                  FROM stats_graph.node
+                                                  ORDER BY id LIMIT 1)),
+                                   99999),
+                           '{}'::jsonb, NULL)::vertex);
+
+-- the graph can be named instead of read from graph_path
+SELECT count(*) FROM meta.vertex_stats(NULL, 'stats_graph');
+
+-- and a preceding clause drives the whole-graph form as it does the others
+UNWIND [1] AS x CALL meta.vertex_stats() YIELD id, out_degree
+RETURN count(id), sum(out_degree);
+
+DROP GRAPH stats_graph CASCADE;
+SET graph_path = graph1;
+
 -- clean up
 DROP GRAPH graph1 CASCADE;
 


### PR DESCRIPTION
Fixes AGV2-352 — in the meta extension, as you asked.

- The vertex is optional: named, one index read; left out, every vertex in one pass. The example in the ticket took 55 seconds on a million vertices asked per vertex, 1.8 seconds this way.
- A table rather than a map, so CALL ... YIELD can name the columns. With meta on search_path the ticket's syntax still gives the map.
- meta 1/1 and regression 252/252, with negative controls for the self-loop rule and the vertex lookup.

---

Fixes AGV2-352 — 지시대로 meta 확장에 넣었습니다.

- 정점 인자는 선택입니다. 주면 인덱스 조회 한 번, 안 주면 엣지를 한 번 훑어 전체가 나옵니다. 티켓의 예시가 정점당 호출로는 100만 정점에 55초, 이 방식으로는 1.8초였습니다.
- 맵이 아니라 테이블입니다. 그래야 `CALL ... YIELD` 로 컬럼을 지정할 수 있습니다. `search_path` 에 `meta` 를 두면 티켓 문법도 그대로 맵을 냅니다.
- meta 1/1 · 회귀 252/252, 셀프루프 규칙과 정점 조회에 각각 음성 대조군.
