### PR TITLE
feat: read how many vertices and edges a graph holds from the meta extension

### DIFF
--- a/contrib/meta/expected/meta.out
+++ b/contrib/meta/expected/meta.out
@@ -621,6 +621,87 @@ FILTER label_name = 'person' RETURN label_name;
  "person"
 (1 row)
 
+--
+-- meta.graph_stats()
+--
+-- The vertices and the edges are counted under one snapshot, so the pair
+-- always describes one state of the graph.
+--
+CREATE GRAPH gs_graph;
+SET graph_path = gs_graph;
+CREATE (:node {n: 'a'}), (:node {n: 'b'}), (:node {n: 'c'});
+MATCH (a:node {n: 'a'}), (b:node {n: 'b'}) CREATE (a)-[:link]->(b);
+MATCH (b:node {n: 'b'}), (c:node {n: 'c'}) CREATE (b)-[:link]->(c);
+-- graph_path names the graph when the caller does not
+SELECT * FROM meta.graph_stats();
+  graph   | vertices | edges 
+----------+----------+-------
+ gs_graph |        3 |     2
+(1 row)
+
+SELECT * FROM meta.graph_stats('gs_graph');
+  graph   | vertices | edges 
+----------+----------+-------
+ gs_graph |        3 |     2
+(1 row)
+
+-- a label that inherits another is counted as well, since every label
+-- inherits ag_vertex or ag_edge
+CREATE VLABEL employee INHERITS (node);
+CREATE ELABEL reports INHERITS (link);
+CREATE (:employee {n: 'e'});
+MATCH (a:node {n: 'a'}), (e:employee {n: 'e'}) CREATE (a)-[:reports]->(e);
+SELECT * FROM meta.graph_stats();
+  graph   | vertices | edges 
+----------+----------+-------
+ gs_graph |        4 |     3
+(1 row)
+
+-- the same two numbers meta.count() gives for the base labels
+SELECT meta.count('ag_vertex') AS vertices, meta.count('ag_edge') AS edges;
+ vertices | edges 
+----------+-------
+        4 |     3
+(1 row)
+
+-- an empty graph answers with zeros rather than with no row
+CREATE GRAPH gs_empty;
+SELECT * FROM meta.graph_stats('gs_empty');
+  graph   | vertices | edges 
+----------+----------+-------
+ gs_empty |        0 |     0
+(1 row)
+
+-- as a Cypher routine
+MATCH (a:node {n: 'a'}) CALL meta.graph_stats() YIELD graph, vertices, edges
+RETURN graph, vertices, edges;
+   graph    | vertices | edges 
+------------+----------+-------
+ "gs_graph" | 4        | 3
+(1 row)
+
+-- a graph the server does not hold
+SELECT * FROM meta.graph_stats('unknown');
+ERROR:  relation "unknown.ag_vertex" does not exist
+LINE 1: ...LECT 'unknown'::name,       (SELECT count(*) FROM unknown.ag...
+                                                             ^
+QUERY:  SELECT 'unknown'::name,       (SELECT count(*) FROM unknown.ag_vertex),       (SELECT count(*) FROM unknown.ag_edge)
+CONTEXT:  PL/pgSQL function meta.graph_stats(name) line 22 at RETURN QUERY
+DROP GRAPH gs_graph CASCADE;
+NOTICE:  drop cascades to 7 other objects
+DETAIL:  drop cascades to sequence gs_graph.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel node
+drop cascades to elabel link
+drop cascades to vlabel employee
+drop cascades to elabel reports
+DROP GRAPH gs_empty CASCADE;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to sequence gs_empty.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+SET graph_path = graph1;
 -- clean up
 DROP GRAPH graph1 CASCADE;
 NOTICE:  drop cascades to 8 other objects

--- a/contrib/meta/meta--1.0.sql
+++ b/contrib/meta/meta--1.0.sql
@@ -788,3 +788,39 @@ $$;
 
 COMMENT ON FUNCTION meta.estimated_edge_density(NAME)
 IS 'Estimates edge density using Postgresql statistics (pg_class.reltuples). Uses graph_path if graph name is not provided.';
+
+CREATE FUNCTION meta.graph_stats(graph_name name DEFAULT NULL)
+RETURNS TABLE(graph name, vertices BIGINT, edges BIGINT)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+    schema_name name;
+BEGIN
+    IF graph_name IS NULL THEN
+        BEGIN
+            schema_name := current_setting('graph_path');
+            IF schema_name IS NULL OR schema_name = '' THEN
+                RAISE NOTICE 'graph_path is not set. Provide graph name or set graph_path';
+                RETURN;
+            END IF;
+            graph_name := schema_name;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'graph_path is not set. Provide graph name or set graph_path';
+            RETURN;
+        END;
+    END IF;
+
+    -- Both counts come from one statement so that they are read under one
+    -- snapshot.  Counting the vertices and the edges in turn would let a write
+    -- land between the two and answer with a graph that never existed.
+    RETURN QUERY EXECUTE format(
+        'SELECT %L::name,'
+        '       (SELECT count(*) FROM %I.ag_vertex),'
+        '       (SELECT count(*) FROM %I.ag_edge)',
+        graph_name, graph_name, graph_name);
+END;
+$$;
+
+COMMENT ON FUNCTION meta.graph_stats(name)
+IS 'Returns the name of a graph and the number of vertices and edges it holds, both read under one snapshot. Every label is counted, since each inherits ag_vertex or ag_edge. Uses graph_path if graph name is not provided.';

--- a/contrib/meta/sql/meta.sql
+++ b/contrib/meta/sql/meta.sql
@@ -193,6 +193,49 @@ RETURN label_name ORDER BY label_name;
 MATCH (a:person {name: 'Alice'}) CALL meta.labels() YIELD label_name
 FILTER label_name = 'person' RETURN label_name;
 
+--
+-- meta.graph_stats()
+--
+-- The vertices and the edges are counted under one snapshot, so the pair
+-- always describes one state of the graph.
+--
+CREATE GRAPH gs_graph;
+SET graph_path = gs_graph;
+
+CREATE (:node {n: 'a'}), (:node {n: 'b'}), (:node {n: 'c'});
+MATCH (a:node {n: 'a'}), (b:node {n: 'b'}) CREATE (a)-[:link]->(b);
+MATCH (b:node {n: 'b'}), (c:node {n: 'c'}) CREATE (b)-[:link]->(c);
+
+-- graph_path names the graph when the caller does not
+SELECT * FROM meta.graph_stats();
+SELECT * FROM meta.graph_stats('gs_graph');
+
+-- a label that inherits another is counted as well, since every label
+-- inherits ag_vertex or ag_edge
+CREATE VLABEL employee INHERITS (node);
+CREATE ELABEL reports INHERITS (link);
+CREATE (:employee {n: 'e'});
+MATCH (a:node {n: 'a'}), (e:employee {n: 'e'}) CREATE (a)-[:reports]->(e);
+SELECT * FROM meta.graph_stats();
+
+-- the same two numbers meta.count() gives for the base labels
+SELECT meta.count('ag_vertex') AS vertices, meta.count('ag_edge') AS edges;
+
+-- an empty graph answers with zeros rather than with no row
+CREATE GRAPH gs_empty;
+SELECT * FROM meta.graph_stats('gs_empty');
+
+-- as a Cypher routine
+MATCH (a:node {n: 'a'}) CALL meta.graph_stats() YIELD graph, vertices, edges
+RETURN graph, vertices, edges;
+
+-- a graph the server does not hold
+SELECT * FROM meta.graph_stats('unknown');
+
+DROP GRAPH gs_graph CASCADE;
+DROP GRAPH gs_empty CASCADE;
+SET graph_path = graph1;
+
 -- clean up
 DROP GRAPH graph1 CASCADE;
 


### PR DESCRIPTION
Fixes AGV2-356 — meta.graph_stats() gives a graph's vertex and edge counts in one call.

- Regression 1/1. Negative control: breaking the edge count fails the test.
- Conflicts with #836 (AGV2-352) — both append to meta--1.0.sql. Whichever lands second needs a rebase.
- The estimated counterpart is filed separately as AGV2-602; exact counts are a full scan.
